### PR TITLE
provide more response data to clients

### DIFF
--- a/src/mw-response-toast-handler/services/mw_response_toast_handler.js
+++ b/src/mw-response-toast-handler/services/mw_response_toast_handler.js
@@ -35,6 +35,8 @@ angular.module('mwUI.ResponseToastHandler')
           data.$count = prevToast ? prevToast.replaceCount + 1 : 0;
           data.$count++;
 
+          data.$httpStatusCode = $httpResponse.status;
+
           if (options.preProcess) {
             _.extend(data, $httpResponse.data);
 

--- a/src/mw-response-toast-handler/services/mw_response_toast_handler_test.js
+++ b/src/mw-response-toast-handler/services/mw_response_toast_handler_test.js
@@ -192,6 +192,12 @@ describe('mwUi Response Handler', function () {
       expect(i18n.get.calls.argsFor(2)[1].$count).toBe(3);
     });
 
+    it('should provide the status of the response', function() {
+      _handleResponse();
+
+      expect(i18n.get.calls.argsFor(0)[1].$httpStatusCode).toBe(200);
+    });
+
     it('should add the singular message when the route is matching the first and replace it with the plural message when another request is coming', function () {
       spyOn(Toast, 'addToast').and.callThrough();
 


### PR DESCRIPTION
sometimes a browser, e.g. firefox 48.0.0.2 will provide a status code of `-1`. this will go through the http interceptor in the uikit and reach the library users. By having this field we allow the library users to handle non proper http response codes, such as `-1` differently.

The `-1` is not present in Chrome or Firefox Nightly