### PR TITLE
Fix/list footer spinner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # 1.0.2
+## Bugfixes
+### List module
+- The loading spinner of `mw-list-footer` will be only displayed when the collection is fetching data
+and has a next page (#19)
+
 ## Features
 ### Backbone Module
 - Collection got a request method that works as the request method of the model. 

--- a/src/mw-backbone/collection/filterable_collection.js
+++ b/src/mw-backbone/collection/filterable_collection.js
@@ -19,7 +19,7 @@ mwUI.Backbone.FilterableCollection = Backbone.FilterableCollection = Backbone.Co
     }
   },
   constructor: function (attributes, options) {
-    var superConstructor = Backbone.Model.prototype.constructor.call(this, attributes, options);
+    var superConstructor = Backbone.Collection.prototype.constructor.call(this, attributes, options);
     this.filterableCollectionConstructor(options);
     return superConstructor;
   },

--- a/src/mw-list/directives/mw_list_footer_row.js
+++ b/src/mw-list/directives/mw_list_footer_row.js
@@ -9,15 +9,15 @@ angular.module('mwUI.List')
         scope.columns = mwListCtrl.getColumns();
 
         scope.collection.on('request', function(){
-          scope.isSyncronising = true;
+          scope.isSynchronising = true;
         });
 
         scope.collection.on('sync error', function(){
-          scope.isSyncronising = false;
+          scope.isSynchronising = false;
         });
 
         scope.showSpinner = function(){
-          return scope.isSyncronising && scope.collection.filterable.hasNextPage();
+          return scope.isSynchronising && scope.collection.filterable.hasNextPage();
         };
       }
     };

--- a/src/mw-list/directives/mw_list_footer_row.js
+++ b/src/mw-list/directives/mw_list_footer_row.js
@@ -8,8 +8,16 @@ angular.module('mwUI.List')
         scope.collection = mwListCtrl.getCollection();
         scope.columns = mwListCtrl.getColumns();
 
+        scope.collection.on('request', function(){
+          scope.isSyncronising = true;
+        });
+
+        scope.collection.on('sync error', function(){
+          scope.isSyncronising = false;
+        });
+
         scope.showSpinner = function(){
-          return /*Loading.isLoading() &&*/ scope.collection.filterable.hasNextPage();
+          return scope.isSyncronising && scope.collection.filterable.hasNextPage();
         };
       }
     };

--- a/src/mw-list/directives/mw_list_footer_row_test.js
+++ b/src/mw-list/directives/mw_list_footer_row_test.js
@@ -52,7 +52,7 @@ describe('mwListHeader', function () {
     this.$httpBackend.flush();
   });
 
-  it('shows removes spinner when the loading of the collection is done', function(){
+  it('removes spinner when the loading of the collection is done', function(){
     this.collectionHasNextPage = true;
     this.scope.collection.fetch();
     this.$httpBackend.expectGET(/\/test.*/).respond(200);

--- a/src/mw-list/directives/mw_list_footer_row_test.js
+++ b/src/mw-list/directives/mw_list_footer_row_test.js
@@ -1,0 +1,77 @@
+describe('mwListHeader', function () {
+
+  beforeEach(module('karmaDirectiveTemplates'));
+
+  beforeEach(module('mwUI.List'));
+
+  window.mockI18nFilter();
+
+  beforeEach(inject(function ($compile, $rootScope, $httpBackend) {
+
+    this.$compile = $compile;
+    this.$httpBackend = $httpBackend;
+    this.$rootScope = $rootScope;
+    this.scope = $rootScope.$new();
+    this.template = '<table mw-listable-bb collection="collection"></table>';
+    this.collection = new (mwUI.Backbone.Collection.extend({
+      url: '/test'
+    }))();
+    this.collectionHasNextPage = false;
+    this.collection.filterable.hasNextPage = jasmine.createSpy('hasNextPage').and.callFake(function(){
+      return this.collectionHasNextPage;
+    }.bind(this));
+    this.scope.collection = this.collection;
+    this.$el = $compile(this.template)(this.scope);
+    this.scope.$digest();
+    this.$footerRowEl = this.$el.find('.mw-list-footer');
+  }));
+
+  afterEach(function () {
+    this.collectionHasNextPage = false;
+    this.$httpBackend.verifyNoOutstandingExpectation();
+    this.scope.$destroy();
+  });
+
+  it('shows no spinner when the collection is not loading', function(){
+    this.collectionHasNextPage = true;
+    var $spinnerEl = this.$footerRowEl.find('.mw-spinner');
+    this.scope.$digest();
+
+    expect($spinnerEl.length).toBe(0);
+  });
+
+  it('shows a spinner when the collection is loading and has a next page', function(){
+    this.collectionHasNextPage = true;
+    this.scope.collection.fetch();
+    this.$httpBackend.expectGET(/\/test.*/).respond(200);
+    this.scope.$digest();
+
+    var $spinnerEl = this.$footerRowEl.find('.mw-spinner');
+    expect($spinnerEl.length).toBe(1);
+
+    this.$httpBackend.flush();
+  });
+
+  it('shows removes spinner when the loading of the collection is done', function(){
+    this.collectionHasNextPage = true;
+    this.scope.collection.fetch();
+    this.$httpBackend.expectGET(/\/test.*/).respond(200);
+    this.scope.$digest();
+    this.$httpBackend.flush();
+
+    var $spinnerEl = this.$footerRowEl.find('.mw-spinner');
+    expect($spinnerEl.length).toBe(0);
+  });
+
+  it('shows no spinner when the collection is loading but has no next page', function(){
+    this.collectionHasNextPage = false;
+    this.scope.collection.fetch();
+    this.$httpBackend.expectGET(/\/test.*/).respond(200);
+    this.scope.$digest();
+    var $spinnerEl = this.$footerRowEl.find('.mw-spinner');
+
+    expect($spinnerEl.length).toBe(0);
+
+    this.$httpBackend.flush();
+  });
+});

--- a/src/mw-list/directives/mw_list_header_test.js
+++ b/src/mw-list/directives/mw_list_header_test.js
@@ -5,6 +5,7 @@ describe('mwListHeader', function () {
   beforeEach(module('mwUI.List'));
 
   window.mockI18nFilter();
+  window.mockIconService();
 
   beforeEach(inject(function ($compile, $rootScope, $httpBackend) {
 

--- a/src/mw-list/mw_list.js
+++ b/src/mw-list/mw_list.js
@@ -1,4 +1,4 @@
-angular.module('mwUI.List', ['mwUI.i18n', 'mwUI.Backbone']);
+angular.module('mwUI.List', ['mwUI.i18n', 'mwUI.Backbone', 'mwUI.UiComponents']);
 
 // @include ./directives/mw_list.js
 // @include ./directives/mw_list_body_row.js


### PR DESCRIPTION
- adds fix for https://github.com/mwaylabs/uikit/issues/19 by displaying the spinner only when the collection is fetching
- mw collection constructor will now the correct super backbone constructor
- adds missing dependency `UiComponents` to `List` module