### PR TITLE
Allow opening in new tab

### DIFF
--- a/src/mw-list/directives/mw_list_url_action_button.js
+++ b/src/mw-list/directives/mw_list_url_action_button.js
@@ -5,9 +5,10 @@ angular.module('mwUI.List')
       restrict: 'A',
       require: '^mwListableBb',
       scope: {
-        link: '@mwListableLinkShowBb'
+        link: '@mwListableLinkShowBb',
+        target: '@?'
       },
-      template: '<span mw-link-show="{{link}}"></span>',
+      template: '<span mw-link-show="{{link}}" target="{{target}}"></span>',
       link: function (scope, elm, attr, mwListableCtrl) {
         mwListableCtrl.actionColumns.push(scope.link);
       }

--- a/src/mw-list/directives/mw_list_url_action_button.js
+++ b/src/mw-list/directives/mw_list_url_action_button.js
@@ -8,7 +8,7 @@ angular.module('mwUI.List')
         link: '@mwListableLinkShowBb',
         target: '@?'
       },
-      template: '<span mw-link-show="{{link}}" target="{{target}}"></span>',
+      template: '<span mw-link-show="{{link}}" link-target="{{target}}"></span>',
       link: function (scope, elm, attr, mwListableCtrl) {
         mwListableCtrl.actionColumns.push(scope.link);
       }

--- a/src/mw-list/directives/mw_list_url_action_button_test.js
+++ b/src/mw-list/directives/mw_list_url_action_button_test.js
@@ -1,0 +1,21 @@
+describe('mwListUrlActionButton', function() {
+
+  beforeEach(function() {
+    module('karmaDirectiveTemplates');
+    module('mwUI');
+  });
+
+  beforeEach(inject(function($compile, $rootScope) {
+    this.$compile = $compile;
+    this.scope = $rootScope.$new();
+  }));
+
+  it('contains the link', function() {
+    var element = this.$compile('<mw-listable-bb><span mw-listable-link-show-bb="http://blog.mwaysolutions.com/"></span></mw-listable-bb>')(this.scope);
+
+    this.scope.$digest();
+
+    expect(element.html()).toContain('href="http://blog.mwaysolutions.com/"');
+  });
+
+});

--- a/src/mw-list/directives/mw_list_url_action_button_test.js
+++ b/src/mw-list/directives/mw_list_url_action_button_test.js
@@ -28,4 +28,15 @@ describe('mwListUrlActionButton', function() {
       expect(compiledElement.html()).not.toContain('target="_blank"');
     });
   });
+
+  it('will open the link in a new tab if configured', function() {
+    var compiledElement = this.$compile('<mw-listable-bb>' +
+      '<span mw-listable-link-show-bb="http://blog.mwaysolutions.com/"' +
+      '      target="_blank"></span>' +
+      '</mw-listable-bb>')(this.scope);
+
+    this.scope.$digest();
+
+    expect(compiledElement.html()).toContain('target="_blank"');
+  });
 });

--- a/src/mw-list/directives/mw_list_url_action_button_test.js
+++ b/src/mw-list/directives/mw_list_url_action_button_test.js
@@ -25,14 +25,14 @@ describe('mwListUrlActionButton', function() {
     it('does not open the link in a new tab', function() {
       this.scope.$digest();
 
-      expect(compiledElement.html()).not.toContain('target="_blank"');
+      expect(compiledElement.html()).not.toContain(' target=');
     });
   });
 
   it('will open the link in a new tab if configured', function() {
     var compiledElement = this.$compile('<mw-listable-bb>' +
       '<span mw-listable-link-show-bb="http://blog.mwaysolutions.com/"' +
-      '      target="_blank"></span>' +
+      '      link-target="_blank"></span>' +
       '</mw-listable-bb>')(this.scope);
 
     this.scope.$digest();

--- a/src/mw-list/directives/mw_list_url_action_button_test.js
+++ b/src/mw-list/directives/mw_list_url_action_button_test.js
@@ -10,12 +10,22 @@ describe('mwListUrlActionButton', function() {
     this.scope = $rootScope.$new();
   }));
 
-  it('contains the link', function() {
-    var element = this.$compile('<mw-listable-bb><span mw-listable-link-show-bb="http://blog.mwaysolutions.com/"></span></mw-listable-bb>')(this.scope);
+  describe('default behaviour', function() {
+    var compiledElement;
+    beforeEach(function() {
+      compiledElement = this.$compile('<mw-listable-bb><span mw-listable-link-show-bb="http://blog.mwaysolutions.com/"></span></mw-listable-bb>')(this.scope);
+    });
 
-    this.scope.$digest();
+    it('contains the link', function() {
+      this.scope.$digest();
 
-    expect(element.html()).toContain('href="http://blog.mwaysolutions.com/"');
+      expect(compiledElement.html()).toContain('href="http://blog.mwaysolutions.com/"');
+    });
+
+    it('does not open the link in a new tab', function() {
+      this.scope.$digest();
+
+      expect(compiledElement.html()).not.toContain('target="_blank"');
+    });
   });
-
 });

--- a/src/mw-ui-components/directives/mw_arrow_link.js
+++ b/src/mw-ui-components/directives/mw_arrow_link.js
@@ -5,7 +5,8 @@ angular.module('mwUI.UiComponents')
     return {
       restrict: 'A',
       scope: {
-        link: '@mwLinkShow'
+        link: '@mwLinkShow',
+        target: '@?'
       },
       templateUrl: 'uikit/mw-ui-components/directives/templates/mw_arrow_link.html'
     };

--- a/src/mw-ui-components/directives/mw_arrow_link.js
+++ b/src/mw-ui-components/directives/mw_arrow_link.js
@@ -6,8 +6,13 @@ angular.module('mwUI.UiComponents')
       restrict: 'A',
       scope: {
         link: '@mwLinkShow',
-        target: '@?'
+        linkTarget: '@?'
       },
-      templateUrl: 'uikit/mw-ui-components/directives/templates/mw_arrow_link.html'
+      templateUrl: 'uikit/mw-ui-components/directives/templates/mw_arrow_link.html',
+      link: function (scope, elm) {
+        if (scope.linkTarget) {
+          elm.attr('target', scope.linkTarget);
+        }
+      }
     };
   });

--- a/src/mw-ui-components/directives/templates/mw_arrow_link.html
+++ b/src/mw-ui-components/directives/templates/mw_arrow_link.html
@@ -1,4 +1,5 @@
 <a ng-href="{{ link }}"
+   target="{{ target }}"
    class="btn btn-default btn-sm mw-arrow-link"
    mw-stop-propagation="click">
   <span mw-icon="mwUI.angleRight"></span>

--- a/src/mw-ui-components/directives/templates/mw_arrow_link.html
+++ b/src/mw-ui-components/directives/templates/mw_arrow_link.html
@@ -1,5 +1,4 @@
 <a ng-href="{{ link }}"
-   target="{{ target }}"
    class="btn btn-default btn-sm mw-arrow-link"
    mw-stop-propagation="click">
   <span mw-icon="mwUI.angleRight"></span>


### PR DESCRIPTION
`mwListableLinkShowBb` can now be used as follows:

```html
<span mw-listable-link-show-bb="http://blog.mwaysolutions.com/"
target="_blank"></span>
```

specifying the target is optional and the existing handling for consumers without specifying `target` has not been changed.

See the testfile for a documentation of the feature