### PR TITLE
Fix/concat url

### DIFF
--- a/src/mw-backbone/utils/concat_url_parts.js
+++ b/src/mw-backbone/utils/concat_url_parts.js
@@ -1,20 +1,19 @@
 mwUI.Backbone.Utils.concatUrlParts = function () {
-  var urlParts = _.toArray(arguments),
-    trimmedUrlParts = [];
+  var urlParts = _.toArray(arguments), cleanedUrlParts = [];
+
+  //remove empty strings
+  urlParts = _.compact(urlParts);
 
   _.forEach(urlParts, function (url, index) {
-    if (!_.isString(url) || url === '') {
-      return;
-    } else if (index !== 0 || url === '/') {
-      //Removes slash at the beginning of the string except when it is the first argument or it is only a slash
-      url = url.replace(/^\//, '');
+    if (index === 0) {
+      //remove only trailing slash
+      url = url.replace(/\/$/g, '');
+    } else {
+      //Removing leading and trailing slash
+      url = url.replace(/^\/|\/$/g, '');
     }
-
-    // Removes trailing slash
-    url = url.replace(/\/$/, '');
-
-    trimmedUrlParts.push(url);
+    cleanedUrlParts.push(url);
   });
 
-  return trimmedUrlParts.join('/');
+  return cleanedUrlParts.join('/');
 };

--- a/src/mw-backbone/utils/concat_url_parts_test.js
+++ b/src/mw-backbone/utils/concat_url_parts_test.js
@@ -44,6 +44,23 @@ describe('Concat url parts', function () {
     expect(result).toMatch('/abc/def');
   });
 
+  it('does not remove slashes in string arguments', function(){
+    var str1 = '/abc',
+      str2 = '/def/ghi/jkl',
+      result = concatUrlParts(str1, str2);
+
+    expect(result).toMatch('/abc/def/ghi/jkl');
+  });
+
+  it('does not remove slash when the arguments before are empty strings', function(){
+    var str1 = '',
+      str2 = '',
+      str3 = '/test',
+      result = concatUrlParts(str1, str2, str3);
+
+    expect(result).toBe('/test');
+  });
+
   it('does not add two slashes to the first position', function(){
     var str1 = '/',
       str2 = '/def',


### PR DESCRIPTION
fix issue when first arguments are empty strings and the argument after starts with slash.
For example when hostName of model is `''` and the endpoint `'/endpoint'`. The result will be now `/endpoint` instead of 'endpoint'