### PR TITLE
Feature/modal scope watcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v1.0.3
+## Features
+### Modal Module
+- Modal got a function to watch its scope attributes. It is not recommended to call `modal.getScope()` and add a watcher 
+because the scope will be destroyed on hide so the watchers are gone. If you want to watch on scope attributes
+use the `modal.watchScope(expression, callback)`. It delegates to the angular `scope.$watch` and ensures that you will 
+always watch on the right scope.
+
 # v1.0.2
 ## Features
 ### Ui Module

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mw-uikit",
   "description": "A toolbox to build portals with AngularJS 1.5.x that have a lot of forms and list views for example admin portals to manage data.",
   "author": "Alexander Zarges <a.zarges@mwaysolutions.com> (http://relution.io)",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license":"Apache-2.0",
   "devDependencies": {
     "angular": "1.5.7",

--- a/src/mw-modal/services/mw_modal.js
+++ b/src/mw-modal/services/mw_modal.js
@@ -15,6 +15,7 @@ angular.module('mwUI.Modal')
         _class = modalOptions.class || '',
         _holderEl = modalOptions.el ? modalOptions.el : 'body .module-page',
         _bootStrapModalOptions = bootStrapModalOptions || {},
+        _watchers = [],
         _modalOpened = false,
         _self = this,
         _modal,
@@ -69,6 +70,12 @@ angular.module('mwUI.Modal')
         });
       };
 
+      var _setScopeWatcher = function(){
+        _watchers.forEach(function(watcher){
+          _usedScope.$watch(watcher.expression,watcher.callback);
+        });
+      };
+
       var _resolveLocals = function () {
         var locals = angular.extend({}, _resolve);
         angular.forEach(locals, function (value, key) {
@@ -90,6 +97,7 @@ angular.module('mwUI.Modal')
         var dfd = $q.defer();
 
         _resolveLocals().then(function (locals) {
+          _setScopeWatcher();
           _modal = _compileTemplate(locals);
 
           _usedScope.hideModal = function () {
@@ -134,6 +142,13 @@ angular.module('mwUI.Modal')
 
       this.getScope = function () {
         return _usedScope;
+      };
+
+      this.watchScope = function(expression, callback){
+        _watchers.push({
+          expression: expression,
+          callback: callback
+        });
       };
 
       /**

--- a/src/mw-modal/services/mw_modal_test.js
+++ b/src/mw-modal/services/mw_modal_test.js
@@ -119,6 +119,37 @@ describe('mwUi Modal service', function () {
       expect(this.myModal.getScope().test).toBe('abc');
       expect(this.myModal.getScope().test2).toBe('xyz');
     });
+
+    fit('watches scope attributes', function () {
+      var changeSpy = jasmine.createSpy('changeSpy');
+      this.myModal.watchScope('test', changeSpy);
+      this.myModal.show();
+      this.$rootScope.$digest();
+
+      this.myModal.setScopeAttributes({test: 'abc', test2: 'xyz'});
+      this.$timeout.flush();
+      this.$rootScope.$digest();
+
+      expect(changeSpy).toHaveBeenCalled();
+    });
+
+    fit('still watches scope attributes when modal is reopened', function () {
+      var changeSpy = jasmine.createSpy('changeSpy');
+      this.myModal.watchScope('test', changeSpy);
+      this.myModal.show();
+      this.$rootScope.$digest();
+      this.myModal.destroy();
+      this.$timeout.flush();
+      this.$rootScope.$digest();
+      this.myModal.show();
+      this.$rootScope.$digest();
+
+      this.myModal.setScopeAttributes({test: 'abc', test2: 'xyz'});
+      this.$timeout.flush();
+      this.$rootScope.$digest();
+
+      expect(changeSpy).toHaveBeenCalled();
+    });
   });
 
   describe('testing that modal is appended to dom', function(){

--- a/src/mw-modal/services/mw_modal_test.js
+++ b/src/mw-modal/services/mw_modal_test.js
@@ -120,7 +120,7 @@ describe('mwUi Modal service', function () {
       expect(this.myModal.getScope().test2).toBe('xyz');
     });
 
-    fit('watches scope attributes', function () {
+    it('watches scope attributes', function () {
       var changeSpy = jasmine.createSpy('changeSpy');
       this.myModal.watchScope('test', changeSpy);
       this.myModal.show();
@@ -133,7 +133,7 @@ describe('mwUi Modal service', function () {
       expect(changeSpy).toHaveBeenCalled();
     });
 
-    fit('still watches scope attributes when modal is reopened', function () {
+    it('still watches scope attributes when modal is reopened', function () {
       var changeSpy = jasmine.createSpy('changeSpy');
       this.myModal.watchScope('test', changeSpy);
       this.myModal.show();


### PR DESCRIPTION
Add `watchScope` function to watch attributes of modal scope. Every time the modal is opened it gets a new scope because the other one is destroyed when the modal is closed. This method ensures that you are always watching scope attributes on the right scope also when the modal is reopened