### PR TITLE
Fix/filterable

### DIFF
--- a/src/mw-backbone/collection/filterable.js
+++ b/src/mw-backbone/collection/filterable.js
@@ -9,14 +9,18 @@ mwUI.Backbone.Filterable = function (collectionInstance, options) {
     _page = options.page || 1,
     _perPage = options.perPage || 30,
     _initialFilterValues = {},
-    _initialCustomUrlParams = _.clone(options.customUrlParams),
+    _initialCustomUrlParams = {},
     _filterDefinition = options.filterDefinition,
     _sortOrder = options.sortOrder,
     _totalAmount,
     _lastFilter;
 
-  this.filterValues = options.filterValues || {};
-  this.customUrlParams = options.customUrlParams || {};
+  var _getClone = function (obj) {
+    return JSON.parse(JSON.stringify(obj));
+  };
+
+  this.filterValues = {};
+  this.customUrlParams = {};
   this.fields = options.fields;
   this.filterIsSet = false;
 
@@ -26,7 +30,6 @@ mwUI.Backbone.Filterable = function (collectionInstance, options) {
 
   this.getRequestParams = function (options) {
     options.params = options.params || {};
-    this.filterValues = _.extend({}, this.getInitialFilterValues(), this.filterValues);
     // Filter functionality
     var filter = this.getFilters();
     if (filter) {
@@ -84,6 +87,7 @@ mwUI.Backbone.Filterable = function (collectionInstance, options) {
 
   this.setInitialFilterValues = function (filterValues) {
     _.extend(_initialFilterValues, filterValues);
+    this.filterValues = _.extend({}, _initialFilterValues, this.filterValues);
   };
 
   this.setLimit = function (limit) {
@@ -155,8 +159,8 @@ mwUI.Backbone.Filterable = function (collectionInstance, options) {
   };
 
   this.resetFilters = function () {
-    this.filterValues = this.getInitialFilterValues();
-    this.customUrlParams = _initialCustomUrlParams;
+    this.filterValues = _getClone(_initialFilterValues);
+    this.customUrlParams = _getClone(_initialCustomUrlParams);
     this.filterIsSet = false;
   };
 
@@ -166,10 +170,13 @@ mwUI.Backbone.Filterable = function (collectionInstance, options) {
     }
 
     if (options.filterValues) {
-      //This makes a clone from the current fitlervalues otherwise the objects are referencing to the same
-      var filterValuesClone = JSON.parse(JSON.stringify(options.filterValues));
-      this.setInitialFilterValues(filterValuesClone);
+      _initialFilterValues = _getClone(options.filterValues)
     }
 
+    if (options.customUrlParams) {
+      _initialCustomUrlParams = _getClone(options.customUrlParams)
+    }
+
+    this.resetFilters();
   }.bind(this)());
 };

--- a/src/mw-backbone/collection/filterable.js
+++ b/src/mw-backbone/collection/filterable.js
@@ -170,11 +170,11 @@ mwUI.Backbone.Filterable = function (collectionInstance, options) {
     }
 
     if (options.filterValues) {
-      _initialFilterValues = _getClone(options.filterValues)
+      _initialFilterValues = _getClone(options.filterValues);
     }
 
     if (options.customUrlParams) {
-      _initialCustomUrlParams = _getClone(options.customUrlParams)
+      _initialCustomUrlParams = _getClone(options.customUrlParams);
     }
 
     this.resetFilters();

--- a/src/mw-backbone/collection/filterable_test.js
+++ b/src/mw-backbone/collection/filterable_test.js
@@ -1,4 +1,4 @@
-describe('Filterable', function () {
+fdescribe('Filterable', function () {
 
   beforeEach(function () {
     var fetch = this.fetchSpy = jasmine.createSpy('fetch');
@@ -76,7 +76,7 @@ describe('Filterable', function () {
       expect(this.filterable.getInitialFilterValues()).toEqual(newInitialFilterValues);
     });
 
-    it('does not overwriting other initial filters', function () {
+    it('does not overwrite other initial filters', function () {
       this.filterable.setInitialFilterValues({
         xyz: 'blaa'
       });
@@ -85,6 +85,31 @@ describe('Filterable', function () {
         test: 'xxx',
         xyz: 'blaa'
       });
+    });
+
+    it('does not overwrite initial filters when filter is set', function () {
+      this.filterable.setInitialFilterValues({
+        xyz: 'blaa'
+      });
+
+      this.filterable.setFilters({
+        xyz: 'xxx'
+      });
+
+      expect(this.filterable.getInitialFilterValues().xyz).toMatch('blaa');
+    });
+
+    it('does not overwrite initial filters when filter is set and resetfilters is called', function () {
+      this.filterable.setInitialFilterValues({
+        xyz: 'blaa'
+      });
+      this.filterable.setFilters({
+        xyz: 'xxx'
+      });
+
+      this.filterable.resetFilters();
+
+      expect(this.filterable.getInitialFilterValues().xyz).toMatch('blaa');
     });
 
     it('uses updated initial filters', function () {

--- a/src/mw-backbone/collection/filterable_test.js
+++ b/src/mw-backbone/collection/filterable_test.js
@@ -126,6 +126,39 @@ describe('Filterable', function () {
       });
     });
 
+    it('does not overwrite filter value with initial filter', function () {
+      this.filterable.setFilters({
+        test: '123'
+      });
+
+      this.filterable.setInitialFilterValues({
+        test: 'xxx'
+      });
+
+      expect(this.filterable.getFilters()).toEqual({
+        type: 'string',
+        fieldName: 'test',
+        value: '123'
+      });
+    });
+
+    it('uses updated initial filter value when calling reset', function () {
+      this.filterable.setFilters({
+        test: '123'
+      });
+      this.filterable.setInitialFilterValues({
+        test: 'xxx'
+      });
+
+      this.filterable.resetFilters();
+
+      expect(this.filterable.getFilters()).toEqual({
+        type: 'string',
+        fieldName: 'test',
+        value: 'xxx'
+      });
+    });
+
     it('resets filter values to updated initial filters', function () {
       this.filterable.setInitialFilterValues({
         test: '123'

--- a/src/mw-backbone/collection/filterable_test.js
+++ b/src/mw-backbone/collection/filterable_test.js
@@ -1,4 +1,4 @@
-fdescribe('Filterable', function () {
+describe('Filterable', function () {
 
   beforeEach(function () {
     var fetch = this.fetchSpy = jasmine.createSpy('fetch');
@@ -16,7 +16,7 @@ fdescribe('Filterable', function () {
     this.Filterable = mwUI.Backbone.Filterable;
   });
 
-  describe('testing inital filtervalues', function () {
+  describe('testing initial filter values', function () {
     beforeEach(function () {
       this.opts = _.extend({}, this.filterableOptions, {
         filterValues: {
@@ -40,7 +40,7 @@ fdescribe('Filterable', function () {
       });
     });
 
-    it('updates filtervalues when calling set filters', function () {
+    it('updates filter values when calling set filters', function () {
       this.filterable.setFilters({
         test: 'abc'
       });
@@ -66,7 +66,7 @@ fdescribe('Filterable', function () {
       });
     });
 
-    it('updates intitial filter values', function () {
+    it('updates initial filter values', function () {
       var newInitialFilterValues = {
         test: '123',
         xyz: 'blaa'
@@ -99,7 +99,7 @@ fdescribe('Filterable', function () {
       expect(this.filterable.getInitialFilterValues().xyz).toMatch('blaa');
     });
 
-    it('does not overwrite initial filters when filter is set and resetfilters is called', function () {
+    it('does not overwrite initial filters when filter is set and resetFilters is called', function () {
       this.filterable.setInitialFilterValues({
         xyz: 'blaa'
       });
@@ -126,7 +126,7 @@ fdescribe('Filterable', function () {
       });
     });
 
-    it('resets filtervalues to updated initial filters', function () {
+    it('resets filter values to updated initial filters', function () {
       this.filterable.setInitialFilterValues({
         test: '123'
       });


### PR DESCRIPTION
There was an object referencing issue. When reset filters was called the initial filter values object got the same object reference as filter values. They must not have the same reference otherwise it is impossible to reset the filters to the original state 