### PR TITLE
Add option dismissible

### DIFF
--- a/src/mw-modal/services/mw_modal.js
+++ b/src/mw-modal/services/mw_modal.js
@@ -15,7 +15,7 @@ angular.module('mwUI.Modal')
         _class = modalOptions.class || '',
         _holderEl = modalOptions.el ? modalOptions.el : 'body .module-page',
         _bootStrapModalOptions = bootStrapModalOptions || {},
-        _cancelable = angular.isDefined(modalOptions.cancelable) ? modalOptions.cancelable : true,
+        _dismissable = angular.isDefined(modalOptions.dismissable) ? modalOptions.dismissable : true,
         _watchers = [],
         _modalOpened = false,
         _self = this,
@@ -111,7 +111,7 @@ angular.module('mwUI.Modal')
             _bootstrapModal = _modal.find('.modal');
             _bootStrapModalOptions.show = false;
 
-            if(!_cancelable){
+            if(!_dismissable){
               _bootStrapModalOptions.backdrop =  'static';
               _bootStrapModalOptions.keyboard =  false;
             }

--- a/src/mw-modal/services/mw_modal.js
+++ b/src/mw-modal/services/mw_modal.js
@@ -15,7 +15,7 @@ angular.module('mwUI.Modal')
         _class = modalOptions.class || '',
         _holderEl = modalOptions.el ? modalOptions.el : 'body .module-page',
         _bootStrapModalOptions = bootStrapModalOptions || {},
-        _dismissable = angular.isDefined(modalOptions.dismissable) ? modalOptions.dismissable : true,
+        _dismissible = angular.isDefined(modalOptions.dismissible) ? modalOptions.dismissible : true,
         _watchers = [],
         _modalOpened = false,
         _self = this,
@@ -111,7 +111,7 @@ angular.module('mwUI.Modal')
             _bootstrapModal = _modal.find('.modal');
             _bootStrapModalOptions.show = false;
 
-            if(!_dismissable){
+            if(!_dismissible){
               _bootStrapModalOptions.backdrop =  'static';
               _bootStrapModalOptions.keyboard =  false;
             }

--- a/src/mw-modal/services/mw_modal.js
+++ b/src/mw-modal/services/mw_modal.js
@@ -15,6 +15,7 @@ angular.module('mwUI.Modal')
         _class = modalOptions.class || '',
         _holderEl = modalOptions.el ? modalOptions.el : 'body .module-page',
         _bootStrapModalOptions = bootStrapModalOptions || {},
+        _cancelable = angular.isDefined(modalOptions.cancelable) ? modalOptions.cancelable : true,
         _watchers = [],
         _modalOpened = false,
         _self = this,
@@ -109,6 +110,12 @@ angular.module('mwUI.Modal')
             _modal.addClass(_class);
             _bootstrapModal = _modal.find('.modal');
             _bootStrapModalOptions.show = false;
+
+            if(!_cancelable){
+              _bootStrapModalOptions.backdrop =  'static';
+              _bootStrapModalOptions.keyboard =  false;
+            }
+
             _bootstrapModal.modal(_bootStrapModalOptions);
 
             // We need to overwrite the the original backdrop method with our own one

--- a/src/mw-modal/services/mw_modal_test.js
+++ b/src/mw-modal/services/mw_modal_test.js
@@ -204,6 +204,63 @@ describe('mwUi Modal service', function () {
       this.$timeout.flush();
     });
 
+    it('sets the correct boostrap modal options when cancelable is set to false', function(){
+      var modal = this.Modal.create({
+        templateUrl: 'test/xxx.html',
+        el: 'body',
+        cancelable: false
+      });
+
+      modal.show();
+      jasmine.clock().tick(101);
+      this.$rootScope.$digest();
+
+      expect(this.openSpy.calls.first().object.options.backdrop).toBe('static');
+      expect(this.openSpy.calls.first().object.options.keyboard).toBe(false);
+
+      modal.destroy();
+      jasmine.clock().tick(101);
+      this.$timeout.flush();
+    });
+
+    it('sets the correct boostrap modal options when cancelable is set to true', function(){
+      var modal = this.Modal.create({
+        templateUrl: 'test/xxx.html',
+        el: 'body',
+        cancelable: true
+      });
+
+      modal.show();
+      jasmine.clock().tick(101);
+      this.$rootScope.$digest();
+
+      expect(this.openSpy.calls.first().object.options.backdrop).toBe(true);
+      expect(this.openSpy.calls.first().object.options.keyboard).toBe(true);
+
+      modal.destroy();
+      jasmine.clock().tick(101);
+      this.$timeout.flush();
+    });
+
+    it('sets the correct boostrap modal options when the option cancelable is not defined', function(){
+      var modal = this.Modal.create({
+        templateUrl: 'test/xxx.html',
+        el: 'body',
+        cancelable: true
+      });
+
+      modal.show();
+      jasmine.clock().tick(101);
+      this.$rootScope.$digest();
+
+      expect(this.openSpy.calls.first().object.options.backdrop).toBe(true);
+      expect(this.openSpy.calls.first().object.options.keyboard).toBe(true);
+
+      modal.destroy();
+      jasmine.clock().tick(101);
+      this.$timeout.flush();
+    });
+
   });
 
   describe('testing advanced modal configurations', function () {

--- a/src/mw-modal/services/mw_modal_test.js
+++ b/src/mw-modal/services/mw_modal_test.js
@@ -204,11 +204,11 @@ describe('mwUi Modal service', function () {
       this.$timeout.flush();
     });
 
-    it('sets the correct boostrap modal options when dismissable is set to false', function(){
+    it('sets the correct boostrap modal options when dismissible is set to false', function(){
       var modal = this.Modal.create({
         templateUrl: 'test/xxx.html',
         el: 'body',
-        dismissable: false
+        dismissible: false
       });
 
       modal.show();
@@ -223,11 +223,11 @@ describe('mwUi Modal service', function () {
       this.$timeout.flush();
     });
 
-    it('sets the correct boostrap modal options when dismissable is set to true', function(){
+    it('sets the correct boostrap modal options when dismissible is set to true', function(){
       var modal = this.Modal.create({
         templateUrl: 'test/xxx.html',
         el: 'body',
-        dismissable: true
+        dismissible: true
       });
 
       modal.show();
@@ -242,11 +242,10 @@ describe('mwUi Modal service', function () {
       this.$timeout.flush();
     });
 
-    it('sets the correct boostrap modal options when the option dismissable is not defined', function(){
+    it('sets the correct boostrap modal options when the option dismissible is not defined', function(){
       var modal = this.Modal.create({
         templateUrl: 'test/xxx.html',
-        el: 'body',
-        dismissable: true
+        el: 'body'
       });
 
       modal.show();

--- a/src/mw-modal/services/mw_modal_test.js
+++ b/src/mw-modal/services/mw_modal_test.js
@@ -204,11 +204,11 @@ describe('mwUi Modal service', function () {
       this.$timeout.flush();
     });
 
-    it('sets the correct boostrap modal options when cancelable is set to false', function(){
+    it('sets the correct boostrap modal options when dismissable is set to false', function(){
       var modal = this.Modal.create({
         templateUrl: 'test/xxx.html',
         el: 'body',
-        cancelable: false
+        dismissable: false
       });
 
       modal.show();
@@ -223,11 +223,11 @@ describe('mwUi Modal service', function () {
       this.$timeout.flush();
     });
 
-    it('sets the correct boostrap modal options when cancelable is set to true', function(){
+    it('sets the correct boostrap modal options when dismissable is set to true', function(){
       var modal = this.Modal.create({
         templateUrl: 'test/xxx.html',
         el: 'body',
-        cancelable: true
+        dismissable: true
       });
 
       modal.show();
@@ -242,11 +242,11 @@ describe('mwUi Modal service', function () {
       this.$timeout.flush();
     });
 
-    it('sets the correct boostrap modal options when the option cancelable is not defined', function(){
+    it('sets the correct boostrap modal options when the option dismissable is not defined', function(){
       var modal = this.Modal.create({
         templateUrl: 'test/xxx.html',
         el: 'body',
-        cancelable: true
+        dismissable: true
       });
 
       modal.show();


### PR DESCRIPTION
Fix #55 by adding `dismissible` option. Option controls if modal can be closed by clicking on the backdrop or by hitting the escape button. by default the option is set to true so the modal can be closed by clicking on the backdrop or by hitting esc