### PR TITLE
Fixes/leave confirmation modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# v1.0.6
+## Bug Fixes
+### Form Module
+Fixed missing leave confirmation for form. The leave confirmation should be displayed when the user made changes in a form
+and tries to leave the form (e.g. by navigting to a different page) without submitting the changes.
+The form leave confirmation is available as a directive called mw-form-leave-confirmation that can be applied
+on form elements
+```html
+<form mw-form-leave-confirmation></form>
+```
+
 # v1.0.5
 ## Features
 ### i18n Module

--- a/src/mw-backbone/directives/mw_collection.js
+++ b/src/mw-backbone/directives/mw_collection.js
@@ -2,17 +2,24 @@ angular.module('mwUI.Backbone')
 
   .directive('mwCollection', function () {
     return {
-      require: '?ngModel',
-      link: function (scope, el, attrs, ngModel) {
-        var collection;
+      require: ['?ngModel', '?^form'],
+      link: function (scope, el, attrs, ctrls) {
+        var collection, ngModelCtrl, formCtrl;
+
+        if(ctrls.length>0){
+          ngModelCtrl = ctrls[0];
+        }
+        if(ctrls.length>1){
+          formCtrl = ctrls[1];
+        }
 
         var updateNgModel = function () {
           if(collection.length>0){
-            ngModel.$setViewValue(collection);
-            ngModel.$render();
+            ngModelCtrl.$setViewValue(collection);
+            ngModelCtrl.$render();
           } else {
-            ngModel.$setViewValue(null);
-            ngModel.$render();
+            ngModelCtrl.$setViewValue(null);
+            ngModelCtrl.$render();
           }
         };
 
@@ -23,10 +30,14 @@ angular.module('mwUI.Backbone')
           if (collection) {
             updateNgModel();
             collection.on('add remove reset', updateNgModel);
+            ngModelCtrl.$setPristine();
+            if(formCtrl){
+              formCtrl.$setPristine(ngModelCtrl);
+            }
           }
         };
 
-        if (ngModel) {
+        if (ngModelCtrl) {
           if (scope.mwModel) {
             init();
           } else {

--- a/src/mw-backbone/directives/mw_model.js
+++ b/src/mw-backbone/directives/mw_model.js
@@ -2,9 +2,16 @@ angular.module('mwUI.Backbone')
 
   .directive('mwModel', function () {
     return {
-      require: '?ngModel',
-      link: function (scope, el, attrs, ngModelCtrl) {
-        var model, modelAttr;
+      require: ['?ngModel', '?^form'],
+      link: function (scope, el, attrs, ctrls) {
+        var model, modelAttr, ngModelCtrl, formCtrl;
+
+        if(ctrls.length>0){
+          ngModelCtrl = ctrls[0];
+        }
+        if(ctrls.length>1){
+          formCtrl = ctrls[1];
+        }
 
         var updateNgModel = function () {
           var val = model.get(modelAttr);
@@ -57,6 +64,10 @@ angular.module('mwUI.Backbone')
               throw new Error('The ng-model and the backbone model can not have different values during initialization!');
             } else if (model.get(modelAttr)) {
               updateNgModel();
+              ngModelCtrl.$setPristine();
+              if(formCtrl){
+                formCtrl.$setPristine(ngModelCtrl);
+              }
             } else if (ngModelCtrl.$modelValue) {
               updateBackboneModel();
             }

--- a/src/mw-backbone/directives/mw_model_test.js
+++ b/src/mw-backbone/directives/mw_model_test.js
@@ -91,6 +91,41 @@ describe('testing mwModel', function () {
     });
   });
 
+  describe('dirty check', function(){
+    it('is not dirty when it sets value from backbone model during initialization', function(){
+      var input = '<input type="text" ng-model="text" mw-model="testModel"/>';
+      var $el = this.$compile(input)(this.scope);
+      this.scope.testModel = this.testModel;
+      this.scope.$digest();
+
+      expect($el.hasClass('ng-pristine')).toBeTruthy();
+    });
+
+    it('is dirty when ng-model changes', function(){
+      var input = '<input type="text" ng-model="text" mw-model="testModel"/>';
+      var $el = this.$compile(input)(this.scope);
+      this.scope.testModel = this.testModel;
+      this.scope.$digest();
+
+      $el.val('XYZ').triggerHandler('input');
+      this.scope.$digest();
+
+      expect($el.hasClass('ng-pristine')).toBeFalsy();
+    });
+
+    it('is dirty when mw-model changes', function(){
+      var input = '<input type="text" ng-model="text" mw-model="testModel"/>';
+      var $el = this.$compile(input)(this.scope);
+      this.scope.testModel = this.testModel;
+      this.scope.$digest();
+
+      this.scope.testModel.set('text','XYZ');
+      this.scope.$digest();
+
+      expect($el.hasClass('ng-pristine')).toBeFalsy();
+    });
+  });
+
   describe('updates ngModel when Backbone model changes', function () {
     it('for input type text', function () {
       var input = '<input type="text" ng-model="text" mw-model="testModel"/>';

--- a/src/mw-form/directives/mw_form_leave_confirmation.js
+++ b/src/mw-form/directives/mw_form_leave_confirmation.js
@@ -1,13 +1,13 @@
 angular.module('mwUI.Form')
 
-  .directive('mwFormLeaveConfirmation', function ($window, $document, $location, i18n, Modal, $compile) {
+  .directive('mwFormLeaveConfirmation', function ($compile) {
     return {
       require: '^form',
       link: function (scope, elm, attr, formCtrl) {
 
         var confirmation = $compile('' +
-            '<div mw-leave-confirmation="form.$dirty" ' +
-            'text="{{\'Form.mwFormLeaveConfirmation.isDirty\' | i18n}}">' +
+            '<div mw-leave-confirmation="showConfirmation()" ' +
+            'text="{{\'Form.leaveConfirmation\' | i18n}}">' +
             '</div>')(scope),
           isActive = true;
 

--- a/src/mw-form/directives/mw_form_leave_confirmation.js
+++ b/src/mw-form/directives/mw_form_leave_confirmation.js
@@ -15,6 +15,14 @@ angular.module('mwUI.Form')
           return formCtrl.$dirty && isActive;
         };
 
+        elm.on('submit', function () {
+          isActive = false;
+        });
+
+        elm.on('input', function () {
+          isActive = true;
+        });
+
         elm.append(confirmation);
 
         scope.$on('$destroy', function () {

--- a/src/mw-form/directives/mw_form_leave_confirmation_test.js
+++ b/src/mw-form/directives/mw_form_leave_confirmation_test.js
@@ -1,0 +1,64 @@
+describe('testing mwFormLeaveConfirmation', function () {
+  beforeEach(module('mwUI.Form'));
+
+  window.mockI18nService();
+  var Modal = window.mockModal();
+
+  var fakeRouteChange = function () {
+    this.$rootScope.$broadcast('$locationChangeStart');
+    this.scope.$digest();
+  };
+
+  beforeEach(inject(function ($rootScope, $compile) {
+    this.$rootScope = $rootScope;
+    this.scope = $rootScope.$new();
+    this.$compile = $compile;
+    this.scope.noOp = function (ev) {
+      ev.preventDefault();
+    };
+    var form = '<form name="testform" mw-form-leave-confirmation ng-submit="noOp($event)"><input id="testInput" ng-model="testInputModel" name="test"></form>';
+    this.$form = this.$compile(form)(this.scope);
+  }));
+
+  afterEach(function () {
+    Modal.show.calls.reset();
+    this.$form.submit().triggerHandler('submit');
+  });
+
+  it('does not open leave-confirmation modal when form is pristine (not touched)', function () {
+    fakeRouteChange.apply(this);
+
+    expect(Modal.show).not.toHaveBeenCalled();
+  });
+
+  it('open leave-confirmation modal when form is dirty and user tries to leave the page', function () {
+    this.$form.find('#testInput').val('XXX').triggerHandler('input');
+    this.scope.$digest();
+
+    fakeRouteChange.apply(this);
+
+    expect(Modal.show).toHaveBeenCalled();
+  });
+
+  it('does not open leave-confirmation modal after form has been submitted', function () {
+    this.$form.find('#testInput').val('XXX').triggerHandler('input');
+    this.$form.submit().triggerHandler('submit');
+    this.scope.$digest();
+
+    fakeRouteChange.apply(this);
+
+    expect(Modal.show).not.toHaveBeenCalled();
+  });
+
+  it('does open leave-confirmation modal when form has been submitted and modified afterwards', function () {
+    this.$form.find('#testInput').val('XXX').triggerHandler('input');
+    this.$form.submit().triggerHandler('submit');
+    this.scope.$digest();
+
+    this.$form.triggerHandler('input');
+    this.scope.$digest();
+    fakeRouteChange.apply(this);
+
+    expect(Modal.show).toHaveBeenCalled();
+  });
+});

--- a/src/mw-form/i18n/de_DE.json
+++ b/src/mw-form/i18n/de_DE.json
@@ -1,4 +1,7 @@
 {
+  "Form": {
+    "leaveConfirmation": "Ihre Änderungen wurden noch nicht gespeichert. Wenn Sie diese Seite verlassen gehen diese verloren!"
+  },
   "mwErrorMessages": {
     "required": "ist ein Pflichtfeld",
     "hasToBeValidEmail": "muss eine valide E-Mail Adresse sein",

--- a/src/mw-form/i18n/en_US.json
+++ b/src/mw-form/i18n/en_US.json
@@ -1,4 +1,7 @@
 {
+  "Form": {
+    "leaveConfirmation": "Your changes haven't been saved yet. If you leave this page all changes will be discarded!"
+  },
   "mwErrorMessages": {
     "required": "is required",
     "hasToBeValidEmail": "has to be a valid e-mail",

--- a/src/test/mocks/modal_mock.js
+++ b/src/test/mocks/modal_mock.js
@@ -1,0 +1,20 @@
+'use strict';
+window.mockModal = function(){
+  var Modal = this.Modal = jasmine.createSpyObj('Modal', ['show', 'hide', 'setScopeAttributes']);
+  beforeEach(function(){
+    module(function($provide){
+      $provide.service('Modal', function(){
+
+        return {
+          create: function(){
+            return Modal;
+          },
+          prepare: function(){
+            return this.create;
+          }
+        };
+      });
+    });
+  });
+  return Modal;
+};


### PR DESCRIPTION
Fixes #61 Fixed missing leave confirmation for form. The leave confirmation should be displayed when the user made changes in a form and tries to leave page without submitting them