### PR TITLE
Fix #63 make sure that internal events are only registered once

### DIFF
--- a/src/mw-backbone/collection/selectable.js
+++ b/src/mw-backbone/collection/selectable.js
@@ -20,20 +20,33 @@ mwUI.Backbone.Selectable.Collection = function (collectionInstance, options) {
     }
   };
 
+  var _selectWhenModelIsSelected = function(model){
+    if(!_selected.get(model)){
+      this.select(model);
+    }
+  };
+
+  var _unSelectWhenModelIsUnSelected = function(model){
+    if(_selected.get(model)) {
+      this.unSelect(model);
+    }
+  };
+
+  var _unSelectWhenModelIsUnset = function(model, opts){
+    opts = opts || {};
+    if(opts.unset || !model.id || model.id.length<1){
+      this.unSelect(model);
+    }
+  };
+
   var _bindModelOnSelectListener = function(model){
-    this.listenTo(model.selectable, 'change:select', function(){
-      if(!_selected.get(model)){
-        this.select(model);
-      }
-    }.bind(this));
+    model.selectable.off('change:select', _selectWhenModelIsSelected);
+    model.selectable.on('change:select', _selectWhenModelIsSelected, this);
   };
 
   var _bindModelOnUnSelectListener = function(model){
-    this.listenTo(model.selectable, 'change:unselect', function(){
-      if(_selected.get(model)) {
-        this.unSelect(model);
-      }
-    }.bind(this));
+    model.selectable.off('change:unselect', _unSelectWhenModelIsUnSelected);
+    model.selectable.on('change:unselect', _unSelectWhenModelIsUnSelected, this);
   };
 
   var _setModelSelectableOptions = function (model, options) {
@@ -116,12 +129,8 @@ mwUI.Backbone.Selectable.Collection = function (collectionInstance, options) {
         this.unSelectAll();
       }
 
-      model.on('change', function(model, opts){
-        opts = opts || {};
-        if(opts.unset || !model.id || model.id.length<1){
-          this.unSelect(model);
-        }
-      }, this);
+      model.off('change', _unSelectWhenModelIsUnset);
+      model.on('change', _unSelectWhenModelIsUnset, this);
 
       _selected.add(model);
       _setModelSelectableOptions.call(this, model, options);

--- a/src/mw-backbone/collection/selectable_collection_test.js
+++ b/src/mw-backbone/collection/selectable_collection_test.js
@@ -785,7 +785,7 @@ describe('Collection Selectable', function () {
 
     it('does not add a new change listener on a model when model is selected again', function(){
       collection.first().selectable.select();
-      collection.first().unset('id');
+      collection.first().selectable.unSelect();
 
       collection.first().selectable.select();
 

--- a/src/mw-backbone/collection/selectable_collection_test.js
+++ b/src/mw-backbone/collection/selectable_collection_test.js
@@ -751,4 +751,45 @@ describe('Collection Selectable', function () {
     });
   });
 
+  describe('event registration', function(){
+    it('adds a change:select listener on every model.selectable in the selectable collection', function(){
+      expect(collection.first().selectable._events['change:select']).not.toBeUndefined();
+      expect(collection.first().selectable._events['change:select'].length).toBe(1);
+    });
+
+    it('does not add a new change:select listener on a model.selectable when model is selected', function(){
+      collection.first().selectable.select();
+
+      expect(collection.first().selectable._events['change:select'].length).toBe(1);
+    });
+
+    it('adds a change:unselect listener on every model.selectable in the selectable collection', function(){
+      expect(collection.first().selectable._events['change:unselect']).not.toBeUndefined();
+      expect(collection.first().selectable._events['change:unselect'].length).toBe(1);
+    });
+
+    it('does not add a new change:unselect listener on a model.selectable when model is selected', function(){
+      collection.first().selectable.select();
+
+      collection.first().selectable.unSelect();
+
+      expect(collection.first().selectable._events['change:unselect'].length).toBe(1);
+    });
+
+    it('adds a change listener on every model in the selectable collection when model is selected', function(){
+      collection.first().selectable.select();
+
+      expect(collection.first()._events.change).not.toBeUndefined();
+      expect(collection.first()._events.change.length).toBe(1);
+    });
+
+    it('does not add a new change listener on a model when model is selected again', function(){
+      collection.first().selectable.select();
+      collection.first().unset('id');
+
+      collection.first().selectable.select();
+
+      expect(collection.first()._events.change.length).toBe(1);
+    });
+  });
 });


### PR DESCRIPTION
Backbone does not check if the callback for an event is already registered. Because of this the callbacks where regsitered multiple times. With this fix callbacks are only registered once