### PR TITLE
Fixes/pre selection

### DIFF
--- a/src/mw-backbone/collection/selectable.js
+++ b/src/mw-backbone/collection/selectable.js
@@ -6,6 +6,7 @@ mwUI.Backbone.Selectable.Collection = function (collectionInstance, options) {
     _addPreSelectedToCollection = _options.addPreSelectedToCollection || false,
     _unSelectOnRemove = _options.unSelectOnRemove,
     _preSelected = options.preSelected,
+    _hasPreSelectedItems = !!options.preSelected,
     _selected = new Backbone.Collection();
 
   var _preselect = function () {
@@ -54,14 +55,14 @@ mwUI.Backbone.Selectable.Collection = function (collectionInstance, options) {
         model.selectable.unSelect(options);
       }
 
-      _bindModelOnSelectListener.call(this,model);
-      _bindModelOnUnSelectListener.call(this,model);
+      _bindModelOnSelectListener.call(this, model);
+      _bindModelOnUnSelectListener.call(this, model);
     }
   };
 
-  var _updatePreSelectedModel = function(preSelectedModel, model){
-    if(_preSelected){
-      if(this.isSingleSelection()){
+  var _updatePreSelectedModel = function (preSelectedModel, model) {
+    if (_hasPreSelectedItems) {
+      if (this.isSingleSelection()) {
         _preSelected = model;
       } else {
         _preSelected.remove(preSelectedModel, {silent: true});
@@ -70,13 +71,13 @@ mwUI.Backbone.Selectable.Collection = function (collectionInstance, options) {
     }
   };
 
-  var _updateSelectedModel = function(model){
+  var _updateSelectedModel = function (model) {
     var selectedModel = this.getSelected().get(model);
-    if(selectedModel){
-      _selected.remove(selectedModel, {silent: true});
-      _selected.add(model, {silent: true});
-      _updatePreSelectedModel.call(this,selectedModel, model);
-      _setModelSelectableOptions.call(this,model,{silent: true});
+    if (selectedModel) {
+      this.unSelect(selectedModel, {silent: true});
+      this.select(model, {silent: true});
+      _updatePreSelectedModel.call(this, selectedModel, model);
+      _setModelSelectableOptions.call(this, selectedModel, {silent: true});
     }
   };
 
@@ -116,16 +117,18 @@ mwUI.Backbone.Selectable.Collection = function (collectionInstance, options) {
         this.unSelectAll();
       }
 
-      model.on('change', function(model, opts){
+      model.on('change', function (model, opts) {
         opts = opts || {};
-        if(opts.unset || !model.id || model.id.length<1){
+        if (opts.unset || !model.id || model.id.length < 1) {
           this.unSelect(model);
         }
       }, this);
 
-      _selected.add(model);
+      _selected.add(model, options);
       _setModelSelectableOptions.call(this, model, options);
-      this.trigger('change change:add', model, this);
+      if (!options.silent) {
+        this.trigger('change change:add', model, this);
+      }
     } else {
       throw new Error('The first argument has to be a Backbone Model');
     }
@@ -139,16 +142,18 @@ mwUI.Backbone.Selectable.Collection = function (collectionInstance, options) {
 
   this.unSelect = function (model, options) {
     options = options || {};
-    _selected.remove(model);
+    _selected.remove(model, options);
     _setModelSelectableOptions.call(this, model, options);
-    this.trigger('change change:remove', model, this);
+    if (!options.silent) {
+      this.trigger('change change:remove', model, this);
+    }
   };
 
   this.unSelectAll = function () {
     var selection = this.getSelected().clone();
     selection.each(function (model) {
       this.unSelect(model);
-    },this);
+    }, this);
   };
 
   this.toggleSelectAll = function () {
@@ -181,8 +186,12 @@ mwUI.Backbone.Selectable.Collection = function (collectionInstance, options) {
   this.preSelectModel = function (model) {
     if (model.id) {
 
+      _hasPreSelectedItems = true;
+
       if (!_collection.get(model) && _addPreSelectedToCollection) {
         _collection.add(model);
+      } else if (_collection.get(model)) {
+        model = _collection.get(model);
       }
 
       this.select(model, {force: true, silent: true});
@@ -228,13 +237,13 @@ mwUI.Backbone.Selectable.Collection = function (collectionInstance, options) {
       if (_unSelectOnRemove) {
         this.unSelectAll();
       } else {
-        this.getSelected().each(function(model){
-          _setModelSelectableOptions.call(this,model);
+        this.getSelected().each(function (model) {
+          _setModelSelectableOptions.call(this, model);
         }, this);
       }
     }, this);
 
-    if (_preSelected) {
+    if (_hasPreSelectedItems) {
       _preselect.call(this);
     }
   };

--- a/src/mw-backbone/collection/selectable.js
+++ b/src/mw-backbone/collection/selectable.js
@@ -21,24 +21,24 @@ mwUI.Backbone.Selectable.Collection = function (collectionInstance, options) {
     }
   };
 
-  var _bindModelOnSelectListener = function(model){
-    this.listenTo(model.selectable, 'change:select', function(){
-      if(!_selected.get(model)){
+  var _bindModelOnSelectListener = function (model) {
+    this.listenTo(model.selectable, 'change:select', function () {
+      if (!_selected.get(model)) {
         this.select(model);
       }
     }.bind(this));
   };
 
-  var _bindModelOnUnSelectListener = function(model){
-    this.listenTo(model.selectable, 'change:unselect', function(){
-      if(_selected.get(model)) {
+  var _bindModelOnUnSelectListener = function (model) {
+    this.listenTo(model.selectable, 'change:unselect', function () {
+      if (_selected.get(model)) {
         this.unSelect(model);
       }
     }.bind(this));
   };
 
   var _setModelSelectableOptions = function (model, options) {
-    if(model && model.selectable){
+    if (model && model.selectable) {
       var selectedModel = _selected.get(model);
 
       if (selectedModel) {
@@ -87,7 +87,7 @@ mwUI.Backbone.Selectable.Collection = function (collectionInstance, options) {
 
   this.getDisabled = function () {
     var disabled = new Backbone.Collection();
-    if(_modelHasDisabledFn){
+    if (_modelHasDisabledFn) {
       _collection.each(function (model) {
         if (model.selectable && model.selectable.isDisabled()) {
           disabled.add(model);
@@ -214,22 +214,22 @@ mwUI.Backbone.Selectable.Collection = function (collectionInstance, options) {
   };
 
 
-  var main = function(){
-    if(!(_collection instanceof Backbone.Collection)){
+  var main = function () {
+    if (!(_collection instanceof Backbone.Collection)) {
       throw new Error('The first parameter has to be from type Backbone.Collection');
     }
 
     _collection.on('add', function (model) {
       _modelHasDisabledFn = model.selectable.hasDisabledFn;
-      _setModelSelectableOptions.call(this,model);
-      _updateSelectedModel.call(this,model);
+      _setModelSelectableOptions.call(this, model);
+      _updateSelectedModel.call(this, model);
     }, this);
 
     _collection.on('remove', function (model) {
       if (_unSelectOnRemove) {
         this.unSelect(model);
       } else {
-        _setModelSelectableOptions.call(this,model);
+        _setModelSelectableOptions.call(this, model);
       }
     }, this);
 

--- a/src/mw-backbone/collection/selectable_collection_test.js
+++ b/src/mw-backbone/collection/selectable_collection_test.js
@@ -552,16 +552,12 @@ describe('Collection Selectable', function () {
 
     it('should always have the correct reference', function () {
       var modelA = new mwUI.Backbone.Model({id: 1});
-      var modelB = new mwUI.Backbone.Model({id: 1});
       var mainCollection = new mwUI.Backbone.Collection();
 
       mainCollection.add(modelA);
       modelA.selectable.select();
-      mainCollection.reset();
-      mainCollection.add(modelB);
-      expect(modelB.selectable.isSelected()).toBeTruthy();
-      mainCollection.selectable.unSelectAll();
-      expect(modelB.selectable.isSelected()).toBeFalsy();
+
+      expect(mainCollection.selectable.getSelected().first().cid).toBe(mainCollection.first().cid);
     });
 
     it('should select all models which are in the preselected collection, add them to collection when addPreSelectedToCollection is set to true and set attribute in model selectable isInCollection to true', function () {

--- a/src/mw-backbone/collection/selectable_collection_test.js
+++ b/src/mw-backbone/collection/selectable_collection_test.js
@@ -627,6 +627,57 @@ describe('Collection Selectable', function () {
       mainCollection.selectable.reset();
       expect(mainCollection.selectable.getSelected().length).toBe(2);
     });
+
+    it('preselects models when calling preSelectCollection and updates the reference for models that are already added', function(){
+      var mainCollection = new mwUI.Backbone.Collection(),
+        preSelectCollection = new mwUI.Backbone.Collection();
+      mainCollection.add([
+        new TestModel({id: 1, name: 'Eins'}),
+        new TestModel({id: 2, name: 'Zwei'}),
+        new TestModel({id: 3, name: 'Drei'})
+      ]);
+      preSelectCollection.add([
+        {id: 1},
+        {id: 3}
+      ]);
+
+      mainCollection.selectable.preSelectCollection(preSelectCollection);
+
+      expect(mainCollection.selectable.getSelected().first().cid).toBe(mainCollection.first().cid);
+    });
+
+    it('preselects models when calling preSelectCollection and updates the reference for models that are added afterwards', function(){
+      var mainCollection = new mwUI.Backbone.Collection(),
+        preSelectCollection = new mwUI.Backbone.Collection();
+      preSelectCollection.add([
+        {id: 1},
+        {id: 2}
+      ]);
+      mainCollection.selectable.preSelectCollection(preSelectCollection);
+
+      mainCollection.add([
+        new TestModel({id: 1, name: 'Eins'}),
+        new TestModel({id: 2, name: 'Zwei'})
+      ]);
+
+      expect(mainCollection.selectable.getSelected().first().cid).toBe(mainCollection.first().cid);
+    });
+
+    it('preselects models when calling preSelectCollection and removes them from selection when they are cleared', function(){
+      var mainCollection = new mwUI.Backbone.Collection(),
+        preSelectCollection = new mwUI.Backbone.Collection();
+      preSelectCollection.add([
+        {id: 1}
+      ]);
+      mainCollection.selectable.preSelectCollection(preSelectCollection);
+      mainCollection.add([
+        new TestModel({id: 1, name: 'Eins'})
+      ]);
+
+      mainCollection.first().clear();
+
+      expect(mainCollection.selectable.getSelected().length).toBe(0);
+    });
   });
 
   describe('testing that selectable of model is working', function () {


### PR DESCRIPTION
When the function selectable.preSelectCollection|Model was called and the items where already in the collection the reference was not updated.
This fix makes sure that the reference of selected items is always to the actual model in the collection