### PR TITLE
Fixes/selectable unselet all

### DIFF
--- a/src/mw-backbone/collection/mw_collection.js
+++ b/src/mw-backbone/collection/mw_collection.js
@@ -1,16 +1,25 @@
 mwUI.Backbone.Collection = Backbone.Collection.extend({
   selectable: true,
   filterable: true,
-  hostName: function(){
+  hostName: function () {
     return mwUI.Backbone.hostName;
   },
-  basePath: function(){
+  basePath: function () {
     return mwUI.Backbone.basePath;
   },
   endpoint: null,
   selectableOptions: mwUI.Backbone.SelectableCollection.prototype.selectableOptions,
   filterableOptions: mwUI.Backbone.FilterableCollection.prototype.filterableOptions,
   model: mwUI.Backbone.Model,
+  secureEach: function (callback, ctx) {
+    // This method can be used when items are removed from the collection during the each loop
+    // When doing this in the normal each method you will get referencing issues—in java terms you
+    // would get a ConcurrentModificationException
+    _.pluck(this.models, 'cid').forEach(function (cid, index) {
+      var model = this.get(cid, index);
+      callback.call(ctx, model, index, this.models);
+    }.bind(this));
+  },
   url: function () {
     return window.mwUI.Backbone.Utils.getUrl(this);
   },

--- a/src/mw-backbone/collection/selectable.js
+++ b/src/mw-backbone/collection/selectable.js
@@ -7,7 +7,10 @@ mwUI.Backbone.Selectable.Collection = function (collectionInstance, options) {
     _unSelectOnRemove = _options.unSelectOnRemove,
     _preSelected = options.preSelected,
     _hasPreSelectedItems = !!options.preSelected,
-    _selected = new Backbone.Collection();
+    _selected = new (mwUI.Backbone.Collection.extend({
+      selectable: false,
+      filterable: false
+    }))();
 
   var _preselect = function () {
     if (_preSelected instanceof Backbone.Model) {

--- a/src/mw-backbone/collection/selectable.js
+++ b/src/mw-backbone/collection/selectable.js
@@ -162,8 +162,7 @@ mwUI.Backbone.Selectable.Collection = function (collectionInstance, options) {
   };
 
   this.unSelectAll = function () {
-    var selection = this.getSelected().clone();
-    selection.each(function (model) {
+    this.getSelected().secureEach(function(model){
       this.unSelect(model);
     }, this);
   };

--- a/src/mw-backbone/collection/selectable.js
+++ b/src/mw-backbone/collection/selectable.js
@@ -44,12 +44,12 @@ mwUI.Backbone.Selectable.Collection = function (collectionInstance, options) {
   };
 
   var _bindModelOnSelectListener = function (model) {
-    model.selectable.off('change:select', _selectWhenModelIsSelected);
+    model.selectable.off('change:select', _selectWhenModelIsSelected, this);
     model.selectable.on('change:select', _selectWhenModelIsSelected, this);
   };
 
   var _bindModelOnUnSelectListener = function (model) {
-    model.selectable.off('change:unselect', _unSelectWhenModelIsUnSelected);
+    model.selectable.off('change:unselect', _unSelectWhenModelIsUnSelected, this);
     model.selectable.on('change:unselect', _unSelectWhenModelIsUnSelected, this);
   };
 
@@ -157,7 +157,7 @@ mwUI.Backbone.Selectable.Collection = function (collectionInstance, options) {
 
   this.unSelect = function (model, options) {
     options = options || {};
-    model.off('change', _unSelectWhenModelIsUnset);
+    model.off('change', _unSelectWhenModelIsUnset, this);
     _selected.remove(model, options);
     _setModelSelectableOptions.call(this, model, options);
     if (!options.silent) {

--- a/src/mw-backbone/collection/selectable.js
+++ b/src/mw-backbone/collection/selectable.js
@@ -133,7 +133,10 @@ mwUI.Backbone.Selectable.Collection = function (collectionInstance, options) {
         this.unSelectAll();
       }
 
-      model.off('change', _unSelectWhenModelIsUnset);
+      if (_collection.get(model)) {
+        model = _collection.get(model);
+      }
+
       model.on('change', _unSelectWhenModelIsUnset, this);
 
       _selected.add(model, options);
@@ -154,6 +157,7 @@ mwUI.Backbone.Selectable.Collection = function (collectionInstance, options) {
 
   this.unSelect = function (model, options) {
     options = options || {};
+    model.off('change', _unSelectWhenModelIsUnset);
     _selected.remove(model, options);
     _setModelSelectableOptions.call(this, model, options);
     if (!options.silent) {

--- a/src/mw-backbone/collection/selectable_collection_test.js
+++ b/src/mw-backbone/collection/selectable_collection_test.js
@@ -830,13 +830,31 @@ describe('Collection Selectable', function () {
       expect(collection.first()._events.change.length).toBe(1);
     });
 
-    it('does not add a new change listener on a model when model is selected again', function(){
+    it('removes change listener from a model when model is unselected ', function(){
       collection.first().selectable.select();
       collection.first().selectable.unSelect();
 
+      expect(collection.first()._events.change).toBeUndefined();
+    });
+
+    it('add all listener on select', function(){
       collection.first().selectable.select();
 
-      expect(collection.first()._events.change.length).toBe(1);
+      expect(collection.first()._events.all.length).toBe(2);
+    });
+
+    it('removes all listener on unSelect', function(){
+      collection.first().selectable.select();
+      collection.first().selectable.unSelect();
+
+      expect(collection.first()._events.all.length).toBe(1);
+    });
+
+    it('removes all listener on unSelectAll()', function(){
+      collection.selectable.selectAll();
+      collection.selectable.unSelectAll();
+
+      expect(collection.first()._events.all.length).toBe(1);
     });
   });
 });


### PR DESCRIPTION
`unSelectAll` must not use a clone of the colelction! 
When using clone the context is changing and therefore the event listeners are not unregistered properly.
With the new method `secureEach` of `mwUI.Backbone.Collection` it is possible to iterate over the collection and remove items. [This is not possible with the normal `.each()` function](http://stackoverflow.com/questions/10858935/cleanest-way-to-destroy-every-model-in-a-collection-in-backbone%E2%80%94) and therefore a clone was used