### PR TITLE
extend quickfilter with public filter functionality

### DIFF
--- a/src-relution/templates/mwSidebarBb/mwSidebarFilters.html
+++ b/src-relution/templates/mwSidebarBb/mwSidebarFilters.html
@@ -30,7 +30,7 @@
           {{filter.get('name')}}
         </a>
 
-        <div ng-if="appliedFilter.id===filter.id"
+        <div ng-if="appliedFilter.id===filter.id && filter.canModifyFilter()"
              class="pull-right action-btns hidden-xs hidden-sm">
 
           <button class="btn btn-link"
@@ -62,9 +62,19 @@
     <div ng-if="mwListCollection && filtersAreApplied()" class="panel panel-default margin-top-10 quickfilter-form">
       <div class="panel-body">
         <p>
-         {{'common.saveQuickFilter' | i18n}}
+          {{'common.saveQuickFilter' | i18n}}
         </p>
-        <input type="text" placeholder="{{'common.quickFilterName' | i18n}}" class="margin-top-10" ng-model="viewModel.tmpFilter.attributes.name">
+        <input type="text" placeholder="{{'common.quickFilterName' | i18n}}" class="margin-top-10"
+               ng-model="viewModel.tmpFilter.attributes.name">
+
+        <div ng-if="viewModel.tmpFilter.canCreatePublicFilter()"
+             class="public-filter margin-top-10">
+          <p>
+            <b>{{'common.saveQuickFilterPublic' | i18n}}</b> <span mw-icon="fa-question-circle" tooltip="{{'common.saveQuickFilterPublicTooltip' | i18n}}"></span>
+          </p>
+          <div mw-toggle mw-model="viewModel.tmpFilter.attributes.isPublic" mw-icon-on="fa-globe" mw-icon-off="fa-lock"></div>
+          <hr>
+        </div>
 
         <div class="margin-top-10">
           <button class="btn btn-danger" ng-click="cancelFilterEdit()">

--- a/src-relution/templates/mwSidebarBb/mwSidebarFilters.html
+++ b/src-relution/templates/mwSidebarBb/mwSidebarFilters.html
@@ -59,20 +59,29 @@
   <div class="form" ng-if="viewModel.showFilterForm">
 
     <div ng-transclude></div>
+
     <div ng-if="mwListCollection && filtersAreApplied()" class="panel panel-default margin-top-10 quickfilter-form">
       <div class="panel-body">
         <p>
           {{'common.saveQuickFilter' | i18n}}
         </p>
-        <input type="text" placeholder="{{'common.quickFilterName' | i18n}}" class="margin-top-10"
+        <input type="text"
+               placeholder="{{'common.quickFilterName' | i18n}}"
+               class="margin-top-10"
                ng-model="viewModel.tmpFilter.attributes.name">
 
         <div ng-if="viewModel.tmpFilter.canCreatePublicFilter()"
              class="public-filter margin-top-10">
           <p>
-            <b>{{'common.saveQuickFilterPublic' | i18n}}</b> <span mw-icon="fa-question-circle" tooltip="{{'common.saveQuickFilterPublicTooltip' | i18n}}"></span>
+            <b>{{'common.saveQuickFilterPublic' | i18n}}</b>
+            <span mw-icon="fa-question-circle"
+                  tooltip="{{'common.saveQuickFilterPublicTooltip' | i18n}}">
+            </span>
           </p>
-          <div mw-toggle mw-model="viewModel.tmpFilter.attributes.isPublic" mw-icon-on="fa-globe" mw-icon-off="fa-lock"></div>
+
+          <div mw-toggle mw-model="viewModel.tmpFilter.attributes.isPublic"
+               mw-icon-on="fa-globe"
+               mw-icon-off="fa-lock"></div>
           <hr>
         </div>
 
@@ -89,12 +98,13 @@
         </div>
       </div>
     </div>
+
     <div ng-if="mwListCollection && !filtersAreApplied()" class="margin-top-10">
-      <button class="btn btn-danger btn-block" ng-click="cancelFilterEdit()">
+      <button class="btn btn-danger btn-block"
+              ng-click="cancelFilterEdit()">
         {{'common.cancel' | i18n}}
       </button>
     </div>
 
   </div>
-
 </div>


### PR DESCRIPTION
Make it possible for admins to configure a public quick filter.
When the quick filter is set to public it is visible to all users of the same organisation. 
Only users with a certain role can create and modify public filters. Organisation users can just see them