### PR TITLE
Fix/configure modal holder el

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+#v1.0.10
+## Features
+### Modal Module
+The service mwModalOptions was added to configure global modal options. Those options will be used for all modals except
+the modal configures it differently.
+```js
+angular.module('App')
+
+.config(function (mwModalOptionsProvider) {
+    mwModalOptionsProvider.config({
+      holderEl: '.module-page', // Element where modal should be appended to (default is body)
+      styleClass: 'my-modal-class', // Css class that should be set on the modal when appended to DOM
+      dismissible: false // Whether the user should be able to close modal by clicking on backdrop (default true)
+    });
+  });
+```
+
 # v1.0.9
 ## Bug Fixes
 ### Src-Relution Module

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mw-uikit",
   "description": "A toolbox to build portals with AngularJS 1.5.x that have a lot of forms and list views for example admin portals to manage data.",
   "author": "Alexander Zarges <a.zarges@mwaysolutions.com> (http://relution.io)",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "license":"Apache-2.0",
   "devDependencies": {
     "angular": "1.5.7",

--- a/src-relution/deprecated/mwForm.js
+++ b/src-relution/deprecated/mwForm.js
@@ -10,7 +10,7 @@ angular.module('mwUI.Relution')
       },
       templateUrl: 'uikit/templates/deprecated/mw_form_input.html',
       link: function(){
-        uiDeprecationWarning('The directive mw-form-input has been renamed to mw-input-wrapper. Please use the new directive instead!');
+        window.mwUI.Utils.shims.deprecationWarning('[mwFormInput] The directive mw-form-input has been renamed to mw-input-wrapper. Please use the new directive instead!');
       }
     };
   })
@@ -25,7 +25,7 @@ angular.module('mwUI.Relution')
       },
       templateUrl: 'uikit/templates/deprecated/mw_form_input.html',
       link: function () {
-        uiDeprecationWarning('The directive mw-form-wrapper does not exist anymore. Please use the directive mw-input-wrapper instead!');
+        window.mwUI.Utils.shims.deprecationWarning('[mwFormWrapper] The directive mw-form-wrapper does not exist anymore. Please use the directive mw-input-wrapper instead!');
       }
     };
   })
@@ -41,11 +41,11 @@ angular.module('mwUI.Relution')
       },
       templateUrl: 'uikit/templates/deprecated/mw_form_checkbox.html',
       link: function(scope) {
-        uiDeprecationWarning('The directive mw-form-checkbox does not exist anymore. Please use the directive mw-input-wrapper instead!');
+        window.mwUI.Utils.shims.deprecationWarning('[mwFormCheckbox] The directive mw-form-checkbox does not exist anymore. Please use the directive mw-input-wrapper instead!');
 
         if (scope.badges) {
           var formatBadges = function () {
-            uiDeprecationWarning('The badges attribute of the deprecated mw-form-checkbox is not supported anymore. Please transclude the badges instead');
+            window.mwUI.Utils.shims.deprecationWarning('[mwFormCheckbox] The badges attribute of the deprecated mw-form-checkbox is not supported anymore. Please transclude the badges instead');
             scope.typedBadges = [];
             var splittedBadges = scope.badges.split(',');
             angular.forEach(splittedBadges, function (badge) {
@@ -82,7 +82,7 @@ angular.module('mwUI.Relution')
   .directive('mwCustomCheckbox', function(){
     return {
       link: function(){
-        uiDeprecationWarning('The directive mw-custom-checkbox is deprecated. The custom checkbox is default now. You can remove this directive from the checkbox input element');
+        window.mwUI.Utils.shims.deprecationWarning('[mwCustomCheckbox] The directive mw-custom-checkbox is deprecated. The custom checkbox is default now. You can remove this directive from the checkbox input element');
       }
     };
   })
@@ -90,7 +90,7 @@ angular.module('mwUI.Relution')
   .directive('mwCustomRadio', function(){
     return {
       link: function(){
-        uiDeprecationWarning('The directive mw-custom-radio is deprecated. The custom radio box is default now. You can remove this directive from the radio input element');
+        window.mwUI.Utils.shims.deprecationWarning('[mwCustomRadio] The directive mw-custom-radio is deprecated. The custom radio box is default now. You can remove this directive from the radio input element');
       }
     };
   })
@@ -98,7 +98,7 @@ angular.module('mwUI.Relution')
   .directive('mwCustomSelect', function(){
     return {
       link: function(){
-        uiDeprecationWarning('The directive mw-custom-select is deprecated. The custom selectbox is default now. You can remove this directive from the select input');
+        window.mwUI.Utils.shims.deprecationWarning('[mwCustomSelect] The directive mw-custom-select is deprecated. The custom selectbox is default now. You can remove this directive from the select input');
       }
     };
   })
@@ -118,7 +118,7 @@ angular.module('mwUI.Relution')
         if (scope.mwOptionsCollection.length === 0) {
           scope.mwOptionsCollection.fetch();
         }
-        uiDeprecationWarning('The directive mw-form-multi-select-2 is deprecated. It has been renamed to mw-checkbox-group. ' +
+        window.mwUI.Utils.shims.deprecationWarning('[mwFormMultiSelect2] The directive mw-form-multi-select-2 is deprecated. It has been renamed to mw-checkbox-group. ' +
           'The new directive wont fetch the options collection automatically when it is empty');
       }
     };

--- a/src-relution/mwUI.js
+++ b/src-relution/mwUI.js
@@ -46,11 +46,3 @@ angular.module('mwUI.Relution', [
     }
   })();
 });
-
-var shownDeprecationWarnings = [];
-window.uiDeprecationWarning = function(message){
-  if(shownDeprecationWarnings.indexOf(message) === -1){
-    console.warn(message);
-    shownDeprecationWarnings.push(message);
-  }
-};

--- a/src/mw-modal/mw_modal.js
+++ b/src/mw-modal/mw_modal.js
@@ -6,6 +6,7 @@ angular.module('mwUI.Modal', ['mwUI.i18n', 'mwUI.Toast']);
 // @include ./directives/mw_modal_footer.js
 
 // @include ./services/mw_modal.js
+// @include ./services/mw_modal_options.js
 // @include ./services/mw_modal_template.js
 
 // @include ./shims/bootstrap_modal.js

--- a/src/mw-modal/services/mw_modal.js
+++ b/src/mw-modal/services/mw_modal.js
@@ -1,21 +1,17 @@
 angular.module('mwUI.Modal')
 
-  .service('Modal', function ($rootScope, $templateCache, $document, $compile, $controller, $injector, $q, $templateRequest, $timeout, Toast) {
+  .service('Modal', function ($rootScope, $templateCache, $document, $compile, $controller, $injector, $q, $templateRequest, $timeout, mwModalOptions, Toast) {
 
     var _openedModals = [];
 
     var Modal = function (modalOptions, bootStrapModalOptions) {
-
       var _id = modalOptions.templateUrl,
         _scope = modalOptions.scope || $rootScope,
         _scopeAttributes = modalOptions.scopeAttributes || {},
         _resolve = modalOptions.resolve || {},
-        _controllerAs = modalOptions.controllerAs || '$ctrl',
         _controller = modalOptions.controller,
-        _class = modalOptions.class || '',
-        _holderEl = modalOptions.el ? modalOptions.el : 'body',
-        _bootStrapModalOptions = bootStrapModalOptions || {},
-        _dismissible = angular.isDefined(modalOptions.dismissible) ? modalOptions.dismissible : true,
+        _modalOptions = _.extend(mwModalOptions.getOptions(), modalOptions),
+        _bootStrapModalOptions = _.extend(_modalOptions.bootStrapModalOptions, bootStrapModalOptions),
         _watchers = [],
         _modalOpened = false,
         _self = this,
@@ -39,7 +35,7 @@ angular.module('mwUI.Modal')
         if (_controller) {
           locals.$scope = _usedScope;
           locals.modalId = _id;
-          var ctrl = $controller(_controller, locals, true, _controllerAs);
+          var ctrl = $controller(_controller, locals, true, _modalOptions.controllerAs);
           _setAttributes(ctrl.instance, _scopeAttributes);
           _usedController = ctrl();
         }
@@ -108,11 +104,11 @@ angular.module('mwUI.Modal')
 
           _usedScope.$on('COMPILE:FINISHED', function () {
             _modal.addClass('mw-modal');
-            _modal.addClass(_class);
+            _modal.addClass(_modalOptions.styleClass);
             _bootstrapModal = _modal.find('.modal');
             _bootStrapModalOptions.show = false;
 
-            if(!_dismissible){
+            if(!_modalOptions.dismissible){
               _bootStrapModalOptions.backdrop =  'static';
               _bootStrapModalOptions.keyboard =  false;
             }
@@ -129,7 +125,7 @@ angular.module('mwUI.Modal')
                 $bootstrapBackdrop = bootstrapModal.backdrop;
 
               bootstrapModal.backdrop = function (callback) {
-                $bootstrapBackdrop.call(bootstrapModal, callback, $(_holderEl).find('.modal'));
+                $bootstrapBackdrop.call(bootstrapModal, callback, $(_modalOptions.holderEl).find('.modal'));
               };
             }
             /* jshint ignore:end */
@@ -175,7 +171,7 @@ angular.module('mwUI.Modal')
         $rootScope.$broadcast('$modalResolveDependenciesStart');
         _buildModal.call(this).then(function () {
           $rootScope.$broadcast('$modalResolveDependenciesSuccess');
-          angular.element(_holderEl).append(_modal);
+          angular.element(_modalOptions.holderEl).append(_modal);
           _bootstrapModal.modal('show');
           _modalOpened = true;
           _openedModals.push(this);
@@ -314,6 +310,14 @@ angular.module('mwUI.Modal')
      * @returns {Object} Modal
      */
     this.create = function (modalOptions, bootstrapModalOptions) {
+      if(modalOptions && modalOptions.el){
+        modalOptions.holderEl = modalOptions.el;
+      }
+
+      if(modalOptions && modalOptions.class){
+        modalOptions.styleClass = modalOptions.class;
+      }
+
       return new Modal(modalOptions, bootstrapModalOptions);
     };
 

--- a/src/mw-modal/services/mw_modal.js
+++ b/src/mw-modal/services/mw_modal.js
@@ -312,10 +312,12 @@ angular.module('mwUI.Modal')
     this.create = function (modalOptions, bootstrapModalOptions) {
       if(modalOptions && modalOptions.el){
         modalOptions.holderEl = modalOptions.el;
+        window.mwUI.Utils.shims.deprecationWarning('[Modal] The modal options property el was renamed to holderEl');
       }
 
       if(modalOptions && modalOptions.class){
         modalOptions.styleClass = modalOptions.class;
+        window.mwUI.Utils.shims.deprecationWarning('[Modal] The modal options property class was renamed to styleClass');
       }
 
       return new Modal(modalOptions, bootstrapModalOptions);

--- a/src/mw-modal/services/mw_modal.js
+++ b/src/mw-modal/services/mw_modal.js
@@ -165,6 +165,10 @@ angular.module('mwUI.Modal')
        */
       this.show = function () {
         var dfd = $q.defer();
+        var $holderEl = angular.element(_modalOptions.holderEl);
+        if(!$holderEl || $holderEl.length === 0){
+          throw new Error('[Modal] no element could be found for the selector string '+_modalOptions.holderEl+'. Make sure that the element exists')
+        }
         Toast.clear();
         _previousFocusedEl = angular.element(document.activeElement);
         $rootScope.$broadcast('$modalOpenStart');

--- a/src/mw-modal/services/mw_modal.js
+++ b/src/mw-modal/services/mw_modal.js
@@ -167,7 +167,7 @@ angular.module('mwUI.Modal')
         var dfd = $q.defer();
         var $holderEl = angular.element(_modalOptions.holderEl);
         if(!$holderEl || $holderEl.length === 0){
-          throw new Error('[Modal] no element could be found for the selector string '+_modalOptions.holderEl+'. Make sure that the element exists')
+          throw new Error('[Modal] no element could be found for the selector string '+_modalOptions.holderEl+'. Make sure that the element exists');
         }
         Toast.clear();
         _previousFocusedEl = angular.element(document.activeElement);

--- a/src/mw-modal/services/mw_modal_options.js
+++ b/src/mw-modal/services/mw_modal_options.js
@@ -1,0 +1,26 @@
+angular.module('mwUI.Modal')
+
+  .provider('mwModalOptions', function () {
+
+    var _options = {
+      controllerAs: '$ctrl',
+      styleClass: '',
+      holderEl: 'body',
+      dismissible: true,
+      bootStrapModalOptions: {}
+    };
+
+    this.config = function (options) {
+      if (_.isObject(options)) {
+        _.extend(_options, options);
+      }
+    };
+
+    this.$get = function () {
+      return {
+        getOptions: function () {
+          return _.clone(_options);
+        }
+      };
+    };
+  });

--- a/src/mw-modal/services/mw_modal_test.js
+++ b/src/mw-modal/services/mw_modal_test.js
@@ -212,6 +212,15 @@ describe('mwUi Modal service', function () {
       this.$timeout.flush();
     });
 
+    it('throws error when holderEl does not exist', function(){
+      var modal = this.Modal.create({
+        templateUrl: 'test/xxx.html',
+        holderEl: 'not-existing'
+      });
+
+      expect(modal.show).toThrow();
+    });
+
     it('sets the correct boostrap modal options when dismissible is set to false', function(){
       var modal = this.Modal.create({
         templateUrl: 'test/xxx.html',

--- a/src/mw-modal/services/mw_modal_test.js
+++ b/src/mw-modal/services/mw_modal_test.js
@@ -558,7 +558,7 @@ describe('mwUi Modal service', function () {
       });
 
       it('can be configured globally for all modals', function(){
-        mwModalOptionsProvider.config({holderEl: '.custom-el', dismissible: false});
+        mwModalOptionsProvider.config({dismissible: false});
         var modal = this.Modal.create({
           templateUrl: 'test/xxx.html'
         });
@@ -573,7 +573,7 @@ describe('mwUi Modal service', function () {
       });
 
       it('can be configured per modal', function(){
-        mwModalOptionsProvider.config({holderEl: '.custom-el', dismissible: false});
+        mwModalOptionsProvider.config({dismissible: false});
         var modal = this.Modal.create({
           templateUrl: 'test/xxx.html',
           dismissible: true

--- a/src/mw-modal/services/mw_modal_test.js
+++ b/src/mw-modal/services/mw_modal_test.js
@@ -1,12 +1,19 @@
 'use strict';
-
 describe('mwUi Modal service', function () {
+  var mwModalOptionsProvider;
+
   beforeEach(module('karmaDirectiveTemplates'));
 
   beforeEach(module('mwUI.Modal'));
   beforeEach(module('ngMock'));
 
   window.mockIconService();
+
+  beforeEach(function () {
+    module('mwUI.Modal', function (_mwModalOptionsProvider_) {
+      mwModalOptionsProvider = _mwModalOptionsProvider_;
+    });
+  });
 
   beforeEach(inject(function ($rootScope, $templateCache, Modal, $timeout) {
     this.$rootScope = $rootScope;
@@ -468,4 +475,109 @@ describe('mwUi Modal service', function () {
 
   });
 
+  describe('testing configuration', function(){
+    describe('modal holder el', function(){
+      it('is by default body', function(){
+        var modal = this.Modal.create({templateUrl: 'test/xxx.html'});
+
+        modal.show();
+        this.$timeout.flush();
+        this.$rootScope.$digest();
+
+        expect(angular.element('body').find('.mw-modal').length).toBe(1);
+
+        modal.destroy();
+      });
+
+      it('can be configured globally for all modals', function(){
+        angular.element('body').append('<div class="custom-el"></div>');
+
+        mwModalOptionsProvider.config({holderEl: '.custom-el'});
+        var modal = this.Modal.create({templateUrl: 'test/xxx.html'});
+        var modal2 = this.Modal.create({templateUrl: 'test/xxx.html'});
+        modal.show();
+        modal2.show();
+        this.$timeout.flush();
+        this.$rootScope.$digest();
+
+        expect(angular.element('.custom-el').find('.mw-modal').length).toBe(2);
+
+        modal.destroy();
+        modal2.destroy();
+        angular.element('.custom-el').remove();
+      });
+
+      it('can be configured per modal', function(){
+        mwModalOptionsProvider.config({holderEl: '.custom-el'});
+        var modal = this.Modal.create({templateUrl: 'test/xxx.html', holderEl: '.custom-el2'});
+        angular.element('body').append('<div class="custom-el2"></div>');
+
+        modal.show();
+        this.$timeout.flush();
+        this.$rootScope.$digest();
+
+        expect(angular.element('.custom-el2').find('.mw-modal').length).toBe(1);
+
+        modal.destroy();
+        angular.element('.custom-el2').remove();
+      });
+    });
+
+    describe('dismissible option', function(){
+      beforeEach(function(){
+        this.openSpy = jasmine.createSpy('openModal').and.callThrough();
+        window.$.fn.modal.Constructor.prototype.show = this.openSpy;
+        jasmine.clock().install();
+      });
+
+      afterEach(function(){
+        jasmine.clock().uninstall();
+      });
+
+      it('is by default true', function(){
+        var modal = this.Modal.create({
+          templateUrl: 'test/xxx.html'
+        });
+
+        modal.show();
+        jasmine.clock().tick(101);
+        this.$rootScope.$digest();
+
+        expect(this.openSpy.calls.first().object.options.backdrop).toBe(true);
+
+        modal.destroy();
+      });
+
+      it('can be configured globally for all modals', function(){
+        mwModalOptionsProvider.config({holderEl: '.custom-el', dismissible: false});
+        var modal = this.Modal.create({
+          templateUrl: 'test/xxx.html'
+        });
+
+        modal.show();
+        jasmine.clock().tick(101);
+        this.$rootScope.$digest();
+
+        expect(this.openSpy.calls.first().object.options.backdrop).toBe('static');
+
+        modal.destroy();
+      });
+
+      it('can be configured per modal', function(){
+        mwModalOptionsProvider.config({holderEl: '.custom-el', dismissible: false});
+        var modal = this.Modal.create({
+          templateUrl: 'test/xxx.html',
+          dismissible: true
+        });
+
+        modal.show();
+        jasmine.clock().tick(101);
+        this.$rootScope.$digest();
+
+        expect(this.openSpy.calls.first().object.options.backdrop).toBe(true);
+
+        modal.destroy();
+      });
+    });
+  });
 });

--- a/src/mw-utils/mw_utils.js
+++ b/src/mw-utils/mw_utils.js
@@ -24,6 +24,7 @@ window.mwUI.Utils.shims = {};
 // @include ./shims/deep_extend_object.js
 // @include ./shims/dom_observer.js
 // @include ./shims/route_to_regex.js
+// @include ./shims/deprecation_warning.js
 
 angular.module('mwUI.Utils').config(function(i18nProvider){
   i18nProvider.addResource('mw-utils/i18n', 'uikit');

--- a/src/mw-utils/shims/deprecation_warning.js
+++ b/src/mw-utils/shims/deprecation_warning.js
@@ -1,0 +1,10 @@
+var shownDeprecationWarnings = [];
+
+var deprecationWarning = function(message){
+  if(shownDeprecationWarnings.indexOf(message) === -1){
+    console.warn(message);
+    shownDeprecationWarnings.push(message);
+  }
+};
+
+window.mwUI.Utils.shims.deprecationWarning = deprecationWarning;


### PR DESCRIPTION
The service mwModalOptions was added to configure global modal options. Those options will be used for all modals except the modal configures it differently.
With the mwModalOptionsProvider it is possible to configure e.g. the holder element where the modal is appended to fix #85 