### PR TITLE
Fixes/minor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# v1.0.12
+## Features
+### Backbone Module
+- Selectable of the collection was extended with the method `useSelectionFor(modelOrCollection)` to reset the `modelOrCollection`
+with the current selection
+- The `mwUI.Collection` is now triggering the event `change:filterValue` when a filter was set on the filterable
+
+## Fixes
+### Backbone Module
+The page of the filterable is reset to 1 when a filter was set. This fixes the wrong offset when the user has paginated 
+through the collection and changes the filter afterwards e.g. by searching.
+
+### List Module
+The scroll listener of the directive `mwListableHead2` is now only active when the directive is visible to improve performance
+and to fix broken affixed state when a user is e.g. switching from one tab to another
+
 # v1.0.11
 ## Features
 ### Src-Relution Module

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mw-uikit",
   "description": "A toolbox to build portals with AngularJS 1.5.x that have a lot of forms and list views for example admin portals to manage data.",
   "author": "Alexander Zarges <a.zarges@mwaysolutions.com> (http://relution.io)",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "license":"Apache-2.0",
   "devDependencies": {
     "angular": "1.5.7",

--- a/src-relution/mwComponentsBb.js
+++ b/src-relution/mwComponentsBb.js
@@ -88,6 +88,14 @@ angular.module('mwComponentsBb', [])
         el.on('blur', 'input[type=text]', function () {
           el.children().removeClass('is-focused');
         });
+
+        scope.$watch(function () {
+          if (scope.collection.filterable && scope.property) {
+            return scope.collection.filterable.filterValues[scope.property];
+          }
+        }, function (val) {
+          scope.viewModel.searchVal = val;
+        });
       }
     };
   })

--- a/src/mw-backbone/collection/filterable.js
+++ b/src/mw-backbone/collection/filterable.js
@@ -162,6 +162,7 @@ mwUI.Backbone.Filterable = function (collectionInstance, options) {
       }
     }, this);
 
+    this.setPage(1);
     this.filterIsSet = true;
 
   };

--- a/src/mw-backbone/collection/filterable.js
+++ b/src/mw-backbone/collection/filterable.js
@@ -152,11 +152,17 @@ mwUI.Backbone.Filterable = function (collectionInstance, options) {
     return _sortOrder;
   };
 
-  this.setFilters = function (filterMap) {
+  this.setFilters = function (filterMap, options) {
+    options = options || {};
 
     _.forEach(filterMap, function (value, key) {
       if (_.has(this.filterValues, key)) {
         this.filterValues[key] = value;
+        var filterValue = {};
+        filterValue[key] = value;
+        if(_.isUndefined(options.silent) || !options.silent){
+          collectionInstance.trigger('change:filterValue', filterValue);
+        }
       } else {
         throw new Error('Filter named \'' + key + '\' not found, did you add it to filterValues of the model?');
       }
@@ -164,7 +170,6 @@ mwUI.Backbone.Filterable = function (collectionInstance, options) {
 
     this.setPage(1);
     this.filterIsSet = true;
-
   };
 
   this.getFilters = function () {

--- a/src/mw-backbone/collection/selectable.js
+++ b/src/mw-backbone/collection/selectable.js
@@ -228,6 +228,37 @@ mwUI.Backbone.Selectable.Collection = function (collectionInstance, options) {
 
   };
 
+  this.setCollectionFromSelection = function (collection) {
+    var selected = this.getSelected();
+    if (collection instanceof mwUI.Backbone.Collection) {
+      collection.replace(selected.toJSON());
+    } else {
+      throw new Error('[Selectable] The passed collection is not an instance of mwUI.Backbone.Collection');
+    }
+    return collection;
+  };
+
+  this.setModelFromSelection = function (model) {
+    var selected = this.getSelected();
+    if (model instanceof Backbone.Model) {
+      if (selected.length === 0) {
+        model.clear();
+      } else {
+        model.set(selected.first().toJSON());
+      }
+    } else {
+      throw new Error('[Selectable] The passed model is not an instance of Backbone.Model');
+    }
+    return model;
+  };
+
+  this.useSelectionFor = function (modelOrCollection) {
+    if (modelOrCollection instanceof Backbone.Model) {
+      return this.setModelFromSelection(modelOrCollection);
+    } else if(modelOrCollection instanceof Backbone.Collection){
+      return this.setCollectionFromSelection(modelOrCollection);
+    }
+  };
 
   var main = function () {
     if (!(_collection instanceof Backbone.Collection)) {

--- a/src/mw-list/directives/mw_list_head.js
+++ b/src/mw-list/directives/mw_list_head.js
@@ -39,6 +39,10 @@ angular.module('mwUI.List')
         var newOffset;
 
         var throttledScrollFn = _.throttle(function () {
+          if(!el.is(':visible')){
+            return;
+          }
+
           if (!newOffset) {
             var headerOffset,
               headerHeight,


### PR DESCRIPTION
- Selectable of the collection was extended with the method `useSelectionFor(modelOrCollection)` to reset the `modelOrCollection` with the current selection
- The `mwUI.Collection` is now triggering the event `change:filterValue` when a filter was set on the filterable
- The page of the filterable is reset to 1 when a filter was set. This fixes the wrong offset when the user has paginated 
through the collection and changes the filter afterwards e.g. by searching.
- The scroll listener of the directive `mwListableHead2` is now only active when the directive is visible to improve performance and to fix broken affixed state when a user is e.g. switching from one tab to another