### PR TITLE
Feature/92 menu entry is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@
 with the current selection
 - The `mwUI.Collection` is now triggering the event `change:filterValue` when a filter was set on the filterable
 
+### Menu Module
+- The menu-entry directive was extended with an `is-active` attribute that accepts a function or a boolean.
+This attribute can be used to control the active state of a `mw-menu-entry` programmatically. Can be useful for entries that 
+don't have a url but only a click action. When a manual `is-active` function is defined the url won't be checked
+```html
+<div mw-menu-entry 
+     label="abc"
+     url="#/xyz"
+     is-active="false"></div> <!-- This entry will never be in active state -->
+     
+<div mw-menu-entry 
+     label="abc"
+     url="#/xyz"
+     is-active="true"></div> <!-- This entry will always be in active state -->  
+        
+<div mw-menu-entry 
+     label="abc"
+     url="#/xyz"
+     is-active="ctrl.isEntryActive()"></div> <!-- This entry will be in active state  when the isEntryActive() function returns true -->          
+```
+
 ## Fixes
 ### Backbone Module
 The page of the filterable is reset to 1 when a filter was set. This fixes the wrong offset when the user has paginated 

--- a/src/mw-menu/directives/mw_menu_entry.js
+++ b/src/mw-menu/directives/mw_menu_entry.js
@@ -11,7 +11,8 @@ angular.module('mwUI.Menu')
         class: '@styleClass',
         order: '=',
         activeUrls: '=',
-        action: '&'
+        action: '&',
+        isActive: '&'
       },
       templateUrl: 'uikit/mw-menu/directives/templates/mw_menu_entry.html',
       require: ['mwMenuEntry', '?^^mwMenuEntry', '?^mwMenuTopEntries'],
@@ -74,9 +75,12 @@ angular.module('mwUI.Menu')
             order: scope.order || getDomOrder(),
             activeUrls: scope.activeUrls || [],
             class: scope.class,
-            action: scope.action ? function () {
-                scope.$eval(scope.action);
-              } : null
+            action: attrs.action ? function () {
+              scope.action();
+            } : null,
+            isActive: attrs.isActive ? function () {
+              return scope.isActive();
+            } : null
           });
         };
 

--- a/src/mw-menu/directives/mw_menu_toggle_active_class.js
+++ b/src/mw-menu/directives/mw_menu_toggle_active_class.js
@@ -3,22 +3,35 @@ angular.module('mwUI.Menu')
   .directive('mwMenuToggleActiveClass', function ($rootScope, $location, $timeout) {
     return {
       scope: {
-        entry: '=mwMenuToggleActiveClass'
+        entry: '=mwMenuToggleActiveClass',
+        isActive: '&'
       },
       link: function (scope, el) {
         var setIsActiveState = function () {
           $timeout(function () {
-            var url = $location.url();
+            var url = $location.url(),
+              hadClass = el.hasClass('active');
 
             if (scope.entry.hasActiveSubEntryOrIsActiveForUrl(url)) {
               el.addClass('active');
             } else {
               el.removeClass('active');
             }
+
+            if (hadClass !== el.hasClass('active')) {
+              scope.$emit('menu-toggle-active-class-changed', el.hasClass('active'));
+            }
           });
         };
 
+        if (scope.entry && scope.entry.get('isActive')) {
+          scope.$watch(function () {
+            return scope.entry.get('isActive')();
+          }, setIsActiveState);
+        }
+
         setIsActiveState();
+        $rootScope.$on('menu-toggle-active-class-changed', setIsActiveState);
         $rootScope.$on('$locationChangeSuccess', setIsActiveState);
         $rootScope.$on('$routeChangeError', setIsActiveState);
       }

--- a/src/mw-menu/directives/mw_menu_toggle_active_class_test.js
+++ b/src/mw-menu/directives/mw_menu_toggle_active_class_test.js
@@ -141,8 +141,8 @@ describe('mwUi menu toggle active class directive', function () {
   });
 
   it('is active when an isActive function is defined and the function returns true', function(){
-    this.$scope.entry.set('isActive', function(){return true});
-    var el = this.$compile('<div mw-menu-toggle-active-class="entry"></div>')(this.$scope);
+    this.$scope.entry.set('isActive', function(){return true;});
+    this.$compile('<div mw-menu-toggle-active-class="entry"></div>')(this.$scope);
 
     this.$scope.$digest();
     this.$timeout.flush();
@@ -151,8 +151,8 @@ describe('mwUi menu toggle active class directive', function () {
   });
 
   it('is not active when an isActive function is defined and the function returns false', function(){
-    this.$scope.entry.set('isActive', function(){return false});
-    var el = this.$compile('<div mw-menu-toggle-active-class="entry"></div>')(this.$scope);
+    this.$scope.entry.set('isActive', function(){return false;});
+    this.$compile('<div mw-menu-toggle-active-class="entry"></div>')(this.$scope);
 
     this.$scope.$digest();
     this.$timeout.flush();
@@ -161,9 +161,9 @@ describe('mwUi menu toggle active class directive', function () {
   });
 
   it('is still active when an isActive function is but it is not matching the current url', function(){
-    this.$scope.entry.set('isActive', function(){return true});
+    this.$scope.entry.set('isActive', function(){return true;});
     this.$scope.entry.set('url', '/abc');
-    var el = this.$compile('<div mw-menu-toggle-active-class="entry"></div>')(this.$scope);
+    this.$compile('<div mw-menu-toggle-active-class="entry"></div>')(this.$scope);
 
     this.$location.setUrl('/xyz');
     this.$scope.$digest();
@@ -181,10 +181,10 @@ describe('mwUi menu toggle active class directive', function () {
         id: 2,
         label: 'sub_xxx',
         url: '/abc/xxx',
-        isActive: function(){return true}
+        isActive: function(){return true;}
       }]
     });
-    var el = this.$compile('<div mw-menu-toggle-active-class="entry"></div>')(this.$scope);
+    this.$compile('<div mw-menu-toggle-active-class="entry"></div>')(this.$scope);
 
     this.$location.setUrl('/xyz');
     this.$scope.$digest();
@@ -198,15 +198,15 @@ describe('mwUi menu toggle active class directive', function () {
       id: 1,
       label: 'xxx',
       url: '/xxx',
-      isActive: function(){return false},
+      isActive: function(){return false;},
       subEntries: [{
         id: 2,
         label: 'sub_xxx',
         url: '/abc/xxx',
-        isActive: function(){return true}
+        isActive: function(){return true;}
       }]
     });
-    var el = this.$compile('<div mw-menu-toggle-active-class="entry"></div>')(this.$scope);
+    this.$compile('<div mw-menu-toggle-active-class="entry"></div>')(this.$scope);
 
     this.$location.setUrl('/xyz');
     this.$scope.$digest();
@@ -221,9 +221,9 @@ describe('mwUi menu toggle active class directive', function () {
       id: 1,
       label: 'xxx',
       url: '/xxx',
-      isActive: function(){return this.$scope.isActive}.bind(this)
+      isActive: function(){return this.$scope.isActive;}.bind(this)
     });
-    var el = this.$compile('<div mw-menu-toggle-active-class="entry"></div>')(this.$scope);
+    this.$compile('<div mw-menu-toggle-active-class="entry"></div>')(this.$scope);
     this.$location.setUrl('/xyz');
     this.$scope.$digest();
     this.$timeout.flush();
@@ -241,9 +241,9 @@ describe('mwUi menu toggle active class directive', function () {
       id: 1,
       label: 'xxx',
       url: '/xxx',
-      isActive: function(){return this.$scope.isActive}.bind(this)
+      isActive: function(){return this.$scope.isActive;}.bind(this)
     });
-    var el = this.$compile('<div mw-menu-toggle-active-class="entry"></div>')(this.$scope);
+    this.$compile('<div mw-menu-toggle-active-class="entry"></div>')(this.$scope);
     this.$location.setUrl('/xyz');
     this.$scope.$digest();
     this.$timeout.flush();

--- a/src/mw-menu/directives/mw_menu_toggle_active_class_test.js
+++ b/src/mw-menu/directives/mw_menu_toggle_active_class_test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-fdescribe('mwUi menu toggle active class directive', function () {
+describe('mwUi menu toggle active class directive', function () {
   beforeEach(module('mwUI.Menu'));
 
   beforeEach(function () {

--- a/src/mw-menu/directives/mw_menu_toggle_active_class_test.js
+++ b/src/mw-menu/directives/mw_menu_toggle_active_class_test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-describe('mwUi menu toggle active class directive', function () {
+fdescribe('mwUi menu toggle active class directive', function () {
   beforeEach(module('mwUI.Menu'));
 
   beforeEach(function () {
@@ -138,5 +138,120 @@ describe('mwUi menu toggle active class directive', function () {
     this.$timeout.flush();
 
     expect(this.element.hasClass('active')).toBeFalsy();
+  });
+
+  it('is active when an isActive function is defined and the function returns true', function(){
+    this.$scope.entry.set('isActive', function(){return true});
+    var el = this.$compile('<div mw-menu-toggle-active-class="entry"></div>')(this.$scope);
+
+    this.$scope.$digest();
+    this.$timeout.flush();
+
+    expect(this.element.hasClass('active')).toBeTruthy();
+  });
+
+  it('is not active when an isActive function is defined and the function returns false', function(){
+    this.$scope.entry.set('isActive', function(){return false});
+    var el = this.$compile('<div mw-menu-toggle-active-class="entry"></div>')(this.$scope);
+
+    this.$scope.$digest();
+    this.$timeout.flush();
+
+    expect(this.element.hasClass('active')).toBeFalsy();
+  });
+
+  it('is still active when an isActive function is but it is not matching the current url', function(){
+    this.$scope.entry.set('isActive', function(){return true});
+    this.$scope.entry.set('url', '/abc');
+    var el = this.$compile('<div mw-menu-toggle-active-class="entry"></div>')(this.$scope);
+
+    this.$location.setUrl('/xyz');
+    this.$scope.$digest();
+    this.$timeout.flush();
+
+    expect(this.element.hasClass('active')).toBeTruthy();
+  });
+
+  it('is sets the parent entry to active when a subentry has an isActive function', function(){
+    this.$scope.entry = new mwUI.Menu.MwMenuEntry({
+      id: 1,
+      label: 'xxx',
+      url: '/xxx',
+      subEntries: [{
+        id: 2,
+        label: 'sub_xxx',
+        url: '/abc/xxx',
+        isActive: function(){return true}
+      }]
+    });
+    var el = this.$compile('<div mw-menu-toggle-active-class="entry"></div>')(this.$scope);
+
+    this.$location.setUrl('/xyz');
+    this.$scope.$digest();
+    this.$timeout.flush();
+
+    expect(this.element.hasClass('active')).toBeTruthy();
+  });
+
+  it('does not set parent entry to active when a subentry has an isActive function but the parent has one as well', function(){
+    this.$scope.entry = new mwUI.Menu.MwMenuEntry({
+      id: 1,
+      label: 'xxx',
+      url: '/xxx',
+      isActive: function(){return false},
+      subEntries: [{
+        id: 2,
+        label: 'sub_xxx',
+        url: '/abc/xxx',
+        isActive: function(){return true}
+      }]
+    });
+    var el = this.$compile('<div mw-menu-toggle-active-class="entry"></div>')(this.$scope);
+
+    this.$location.setUrl('/xyz');
+    this.$scope.$digest();
+    this.$timeout.flush();
+
+    expect(this.element.hasClass('active')).toBeFalsy();
+  });
+
+  it('updates state when isActive function changes returns true first but changes to false later', function(){
+    this.$scope.isActive = true;
+    this.$scope.entry = new mwUI.Menu.MwMenuEntry({
+      id: 1,
+      label: 'xxx',
+      url: '/xxx',
+      isActive: function(){return this.$scope.isActive}.bind(this)
+    });
+    var el = this.$compile('<div mw-menu-toggle-active-class="entry"></div>')(this.$scope);
+    this.$location.setUrl('/xyz');
+    this.$scope.$digest();
+    this.$timeout.flush();
+
+    this.$scope.isActive = false;
+    this.$scope.$digest();
+    this.$timeout.flush();
+
+    expect(this.element.hasClass('active')).toBeFalsy();
+  });
+
+  it('updates state when isActive function changes returns false first but changes to true later', function(){
+    this.$scope.isActive = false;
+    this.$scope.entry = new mwUI.Menu.MwMenuEntry({
+      id: 1,
+      label: 'xxx',
+      url: '/xxx',
+      isActive: function(){return this.$scope.isActive}.bind(this)
+    });
+    var el = this.$compile('<div mw-menu-toggle-active-class="entry"></div>')(this.$scope);
+    this.$location.setUrl('/xyz');
+    this.$scope.$digest();
+    this.$timeout.flush();
+
+    this.$scope.isActive = true;
+    this.$scope.$digest();
+    this.$timeout.flush();
+
+    expect(this.element.hasClass('active')).toBeTruthy();
   });
 });

--- a/src/mw-menu/models/mw_menu_entry.js
+++ b/src/mw-menu/models/mw_menu_entry.js
@@ -8,7 +8,9 @@ var MwMenuEntry = window.mwUI.Backbone.NestedModel.extend({
       label: null,
       icon: null,
       activeUrls: [],
-      order: null
+      order: null,
+      action: null,
+      isActive: null
     };
   },
   nested: function () {
@@ -97,14 +99,27 @@ var MwMenuEntry = window.mwUI.Backbone.NestedModel.extend({
   hasSubEntries: function () {
     return this.get('subEntries').length > 0;
   },
+  hasManualActiveFunction: function () {
+    return this.get('isActive') && typeof this.get('isActive') === 'function';
+  },
   isActiveForUrl: function (url) {
-    return this.ownUrlIsActiveForUrl(url) || this.activeUrlIsActiveForUrl(url);
+    if (this.hasManualActiveFunction()) {
+      return this.get('isActive')();
+    } else {
+      return this.ownUrlIsActiveForUrl(url) || this.activeUrlIsActiveForUrl(url);
+    }
   },
   getActiveSubEntryForUrl: function (url) {
     return this.get('subEntries').getActiveEntryForUrl(url);
   },
   hasActiveSubEntryOrIsActiveForUrl: function (url) {
-    return this.get('type') === 'ENTRY' && (!!this.getActiveSubEntryForUrl(url) || this.isActiveForUrl(url));
+    if (this.get('type') === 'ENTRY') {
+      if (this.hasManualActiveFunction()) {
+        return this.get('isActive')();
+      } else {
+        return !!this.getActiveSubEntryForUrl(url) || this.isActiveForUrl(url);
+      }
+    }
   },
   constructor: function (model, options) {
     options = options || {};


### PR DESCRIPTION
The menu-entry directive was extended with an `is-active` attribute that accepts a function or a boolean.
This attribute can be used to control the active state of a `mw-menu-entry` programmatically. Can be useful for entries that don't have a url but only a click action. When a manual `is-active` function is defined the url won't be checked