### PR TITLE
Fix switched icons of sort directions

### DIFF
--- a/src/mw-list/directives/templates/mw_list_header.html
+++ b/src/mw-list/directives/templates/mw_list_header.html
@@ -3,8 +3,8 @@
     ng-click="toggleSortOrder()">
   <span ng-if="canBeSorted()" class="sort-indicators">
     <i ng-show="!isSelected()" mw-icon="mwUI.sort" class="sort-indicator"></i>
-    <i ng-if="isSelected('-')" mw-icon="mwUI.sortAsc"></i>
-    <i ng-if="isSelected('+')" mw-icon="mwUI.sortDesc"></i>
+    <i ng-if="isSelected('+')" mw-icon="mwUI.sortAsc"></i>
+    <i ng-if="isSelected('-')" mw-icon="mwUI.sortDesc"></i>
   </span>
 
   <span ng-transclude class="title"></span>


### PR DESCRIPTION
If we are use a + as sort direction, the backend will sort it ascending. The used icon is desc.
This pull request will switch the + and - selectors