### PR TITLE
Feature/change single selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.0.14
+## Features
+### Backbone module
+- Selectable was extended with the public method `setSingleSelection(true|false)` to change the selection mode.
+It also allows to set single selection to true even though the attribute `preSelected` is a collection.
+
 # v1.0.13
 ## Features
 ### Utils module

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mw-uikit",
   "description": "A toolbox to build portals with AngularJS 1.5.x that have a lot of forms and list views for example admin portals to manage data.",
   "author": "Alexander Zarges <a.zarges@mwaysolutions.com> (http://relution.io)",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "license":"Apache-2.0",
   "devDependencies": {
     "angular": "1.5.7",

--- a/src/mw-backbone/collection/selectable.js
+++ b/src/mw-backbone/collection/selectable.js
@@ -14,10 +14,8 @@ mwUI.Backbone.Selectable.Collection = function (collectionInstance, options) {
 
   var _preselect = function () {
     if (_preSelected instanceof Backbone.Model) {
-      _isSingleSelection = true;
       this.preSelectModel(_preSelected);
     } else if (_preSelected instanceof Backbone.Collection) {
-      _isSingleSelection = false;
       this.preSelectCollection(_preSelected);
     } else {
       throw new Error('The option preSelected has to be either a Backbone Model or Collection');
@@ -193,6 +191,18 @@ mwUI.Backbone.Selectable.Collection = function (collectionInstance, options) {
     return _isSingleSelection;
   };
 
+  this.setSingleSelection = function (isSingleSelection) {
+    if (_preSelected instanceof Backbone.Model) {
+      if (!isSingleSelection) {
+        throw new Error('isSingleSelection can not be set to false when preselected is a model!');
+      } else {
+        _isSingleSelection = true;
+      }
+    } else {
+      _isSingleSelection = isSingleSelection;
+    }
+  };
+
   this.reset = function () {
     this.unSelectAll();
     _preselect.call(this);
@@ -289,10 +299,16 @@ mwUI.Backbone.Selectable.Collection = function (collectionInstance, options) {
       }
     }, this);
 
+    if(_preSelected instanceof Backbone.Model){
+      this.setSingleSelection(true);
+    } else {
+      this.setSingleSelection(_options.isSingleSelection || false);
+    }
+
     if (_hasPreSelectedItems) {
       _preselect.call(this);
     }
-  };
+  }.bind(this);
 
   main.call(this);
 

--- a/src/mw-backbone/collection/selectable_collection_test.js
+++ b/src/mw-backbone/collection/selectable_collection_test.js
@@ -503,7 +503,7 @@ describe('Collection Selectable', function () {
             selectableOptions: function(){
               return {
                 preSelected: collection
-              }
+              };
             }
           }),
         selectableCollection = new SelectableCollection();
@@ -519,7 +519,7 @@ describe('Collection Selectable', function () {
           selectableOptions: function(){
             return {
               preSelected: collection
-            }
+            };
           }
         }),
         selectableCollection = new SelectableCollection();
@@ -535,7 +535,7 @@ describe('Collection Selectable', function () {
           selectableOptions: function(){
             return {
               preSelected: model
-            }
+            };
           }
         }),
         selectableCollection = new SelectableCollection();
@@ -551,7 +551,7 @@ describe('Collection Selectable', function () {
           selectableOptions: function(){
             return {
               preSelected: model
-            }
+            };
           }
         }),
         selectableCollection = new SelectableCollection();

--- a/src/mw-backbone/collection/selectable_collection_test.js
+++ b/src/mw-backbone/collection/selectable_collection_test.js
@@ -480,6 +480,88 @@ describe('Collection Selectable', function () {
       expect(radioCollection.selectable.getSelected().length).toBe(1);
       expect(radioCollection.selectable.getSelected().first().get('id')).toBe(2);
     });
+
+    it('allows to set single selection to true when no preselection was set', function(){
+      var collection = new mwUI.Backbone.Collection();
+
+      collection.selectable.setSingleSelection(true);
+
+      expect(collection.selectable.isSingleSelection()).toBeTruthy();
+    });
+
+    it('allows to set single selection to false when no preselection was set', function(){
+      var collection = new mwUI.Backbone.Collection();
+
+      collection.selectable.setSingleSelection(false);
+
+      expect(collection.selectable.isSingleSelection()).toBeFalsy();
+    });
+
+    it('allows to set single selection to true when no preselection is a collection', function(){
+      var collection = new mwUI.Backbone.Collection(),
+          SelectableCollection = mwUI.Backbone.Collection.extend({
+            selectableOptions: function(){
+              return {
+                preSelected: collection
+              }
+            }
+          }),
+        selectableCollection = new SelectableCollection();
+
+      selectableCollection.selectable.setSingleSelection(true);
+
+      expect(selectableCollection.selectable.isSingleSelection()).toBeTruthy();
+    });
+
+    it('allows to set single selection to false when no preselection is a collection', function(){
+      var collection = new mwUI.Backbone.Collection(),
+        SelectableCollection = mwUI.Backbone.Collection.extend({
+          selectableOptions: function(){
+            return {
+              preSelected: collection
+            }
+          }
+        }),
+        selectableCollection = new SelectableCollection();
+
+      selectableCollection.selectable.setSingleSelection(false);
+
+      expect(selectableCollection.selectable.isSingleSelection()).toBeFalsy();
+    });
+
+    it('allows to set single selection to true when no preselection is a model', function(){
+      var model = new mwUI.Backbone.Model(),
+        SelectableCollection = mwUI.Backbone.Collection.extend({
+          selectableOptions: function(){
+            return {
+              preSelected: model
+            }
+          }
+        }),
+        selectableCollection = new SelectableCollection();
+
+      selectableCollection.selectable.setSingleSelection(true);
+
+      expect(selectableCollection.selectable.isSingleSelection()).toBeTruthy();
+    });
+
+    it('does not allow to set single selection to false when no preselection is a model', function(){
+      var model = new mwUI.Backbone.Model(),
+        SelectableCollection = mwUI.Backbone.Collection.extend({
+          selectableOptions: function(){
+            return {
+              preSelected: model
+            }
+          }
+        }),
+        selectableCollection = new SelectableCollection();
+
+      var throwFn = function () {
+        selectableCollection.selectable.setSingleSelection(false);
+      };
+
+      expect(throwFn).toThrow();
+    });
   });
 
   describe('testing preselection', function () {


### PR DESCRIPTION
- Selectable was extended with the public method `setSingleSelection(true|false)` to change the selection mode.
- Selectable allows to set single selection to true even though the attribute `preSelected` is a collection.