### PR TITLE
Feature/fix collapsable

### DIFF
--- a/src/mw-ui-components/directives/mw_collapsible.js
+++ b/src/mw-ui-components/directives/mw_collapsible.js
@@ -1,7 +1,7 @@
 angular.module('mwUI.UiComponents')
 
 //TODO rename to mwCollapsible
-  .directive('mwCollapsable', function () {
+  .directive('mwCollapsable', function ($timeout) {
     return {
       transclude: true,
       scope: {
@@ -10,39 +10,42 @@ angular.module('mwUI.UiComponents')
       },
       templateUrl: 'uikit/mw-ui-components/directives/templates/mw_collapsible.html',
       link: function (scope, el) {
-        var collapsedBody = el.find('.mw-collapsible > .mw-collapsible-body');
+        var collapsedBody = el.find('.mw-collapsible > .mw-collapsible-body'),
+          collapsedBodyContent = collapsedBody.find('.collapsed-content'),
+          transitionDuration = parseFloat(collapsedBody.css('transition-duration')) * 1000;
 
-        var getHeight = function (el) {
-          var totalHeight = 0;
+        // We need to set an invisible border so the inner height of the transcluded contnet is calculated correctly
+        // https://stackoverflow.com/a/2555030
+        collapsedBodyContent.css('border', '1px solid transparent');
 
-          el.children().filter(':visible').each(function () {
-            totalHeight += angular.element(this).outerHeight(true);
-          });
-          return totalHeight;
+        var getHeight = function () {
+          return collapsedBodyContent.innerHeight();
         };
 
-        var removeMaxHeight = function(){
+        var removeMaxHeight = function () {
           collapsedBody.css('max-height', 'initial');
           collapsedBody.off('transitionend', removeMaxHeight);
         };
 
         var open = function () {
-          //transitionendFromTest is to trigger event from test, transitionend can not be triggered
-          collapsedBody.on('transitionend transitionendFromTest', removeMaxHeight);
-          collapsedBody.css('max-height', getHeight(collapsedBody));
+          var calculatedBodyHeight = getHeight();
+          if (calculatedBodyHeight > 0) {
+            //transitionendFromTest is to trigger event from test, transitionend can not be triggered
+            collapsedBody.on('transitionend transitionendFromTest', removeMaxHeight);
+            collapsedBody.css('max-height', calculatedBodyHeight);
+          }
+          $timeout(removeMaxHeight, transitionDuration);
           scope.isCollapsed = false;
         };
 
         var close = function () {
           collapsedBody.off('transitionend', removeMaxHeight);
-          collapsedBody.css('max-height', getHeight(collapsedBody));
-          setTimeout(function(){
+          collapsedBody.css('max-height', getHeight());
+          $timeout(function () {
             collapsedBody.css('max-height', 0);
           }, 5);
           scope.isCollapsed = true;
         };
-
-        scope.el = el;
 
         scope.toggle = function () {
           if (scope.isCollapsed) {

--- a/src/mw-ui-components/directives/mw_collapsible_test.js
+++ b/src/mw-ui-components/directives/mw_collapsible_test.js
@@ -5,15 +5,17 @@ describe('mwCollapsable', function () {
   var el;
   var collapsable;
   var isolateScope;
+  var $timeout;
 
   beforeEach(module('karmaDirectiveTemplates'));
 
   beforeEach(module('mwUI.UiComponents'));
 
-  beforeEach(inject(function (_$compile_, _$rootScope_) {
+  beforeEach(inject(function (_$compile_, _$rootScope_, _$timeout_) {
     $compile = _$compile_;
     $rootScope = _$rootScope_;
     scope = _$rootScope_.$new();
+    $timeout = _$timeout_;
 
     collapsable = '<div mw-collapsable mw-title="TITLE">TEXTTEXTTEXTTEXTTEXTTEXTTEXTTEXT</div>';
     el = $compile(collapsable)(scope);
@@ -185,7 +187,7 @@ describe('mwCollapsable', function () {
       isolateScope.toggle();
       scope.$digest();
 
-      var expectedHeight = el.find('#testContent1').innerHeight() + el.find('#testContent2').innerHeight() + 4 * margin;
+      var expectedHeight = el.find('#testContent1').innerHeight() + el.find('#testContent2').innerHeight() + 3 * margin;
       expect(el.find('.mw-collapsible-body').css('max-height')).toBe(expectedHeight + 'px');
     });
 
@@ -200,6 +202,36 @@ describe('mwCollapsable', function () {
       isolateScope = el.isolateScope();
       isolateScope.toggle();
       el.find('.mw-collapsible-body').trigger('transitionendFromTest');
+      scope.$digest();
+
+      expect(el.find('.mw-collapsible-body').css('max-height')).toBe('none');
+    });
+
+    it('removes max height when no transition end event is fired during intialisation', function(){
+      var transcludedContent = 'abc';
+      collapsable = '<div mw-collapsable="closed" mw-title="TITLE">' + transcludedContent + '</div>';
+      scope.closed = false;
+
+      el = $compile(collapsable)(scope);
+      angular.element('body').append(el);
+      $timeout.flush();
+      scope.$digest();
+
+      expect(el.find('.mw-collapsible-body').css('max-height')).toBe('none');
+    });
+
+    it('removes max height when no transition end event is fired when it is toggled', function(){
+      var transcludedContent = 'abc';
+      collapsable = '<div mw-collapsable="closed" mw-title="TITLE">' + transcludedContent + '</div>';
+      scope.closed = true;
+      el = $compile(collapsable)(scope);
+      angular.element('body').append(el);
+      scope.$digest();
+      $timeout.flush();
+      isolateScope = el.isolateScope();
+
+      isolateScope.toggle();
+      $timeout.flush();
       scope.$digest();
 
       expect(el.find('.mw-collapsible-body').css('max-height')).toBe('none');

--- a/src/mw-ui-components/directives/mw_collapsible_test.js
+++ b/src/mw-ui-components/directives/mw_collapsible_test.js
@@ -23,7 +23,7 @@ describe('mwCollapsable', function () {
     isolateScope = el.isolateScope();
   }));
 
-  afterEach(function(){
+  afterEach(function () {
     angular.element('body *[mw-collapsable]').remove();
   });
 
@@ -191,7 +191,7 @@ describe('mwCollapsable', function () {
       expect(el.find('.mw-collapsible-body').css('max-height')).toBe(expectedHeight + 'px');
     });
 
-    it('extends its height when its opened', function(){
+    it('extends its height when its opened', function () {
       var transcludedContent = '<div id="testContent">TEXTTEXTTEXTTEXTTEXTTEXTTEXTTEXT</div>';
       collapsable = '<div mw-collapsable="closed" mw-title="TITLE">' + transcludedContent + '</div>';
       scope.closed = true;
@@ -207,7 +207,7 @@ describe('mwCollapsable', function () {
       expect(el.find('.mw-collapsible-body').css('max-height')).toBe('none');
     });
 
-    it('removes max height when no transition end event is fired during intialisation', function(){
+    it('removes max height when no transition end event is fired during intialisation', function () {
       var transcludedContent = 'abc';
       collapsable = '<div mw-collapsable="closed" mw-title="TITLE">' + transcludedContent + '</div>';
       scope.closed = false;
@@ -220,7 +220,7 @@ describe('mwCollapsable', function () {
       expect(el.find('.mw-collapsible-body').css('max-height')).toBe('none');
     });
 
-    it('removes max height when no transition end event is fired when it is toggled', function(){
+    it('removes max height when no transition end event is fired when it is toggled', function () {
       var transcludedContent = 'abc';
       collapsable = '<div mw-collapsable="closed" mw-title="TITLE">' + transcludedContent + '</div>';
       scope.closed = true;

--- a/src/mw-ui-components/directives/mw_collapsible_test.js
+++ b/src/mw-ui-components/directives/mw_collapsible_test.js
@@ -111,8 +111,8 @@ describe('mwCollapsable', function () {
   describe('testing height', function () {
     it('sets max-height when element is opened when transcluded element has no padding and margin', function () {
       var transcludedContent = '<div id="testContent">TEXTTEXTTEXTTEXTTEXTTEXTTEXTTEXT</div>';
-      collapsable = '<div mw-collapsable="opened" mw-title="TITLE">' + transcludedContent + '</div>';
-      scope.opened = false;
+      collapsable = '<div mw-collapsable="closed" mw-title="TITLE">' + transcludedContent + '</div>';
+      scope.closed = true;
 
       el = $compile(collapsable)(scope);
       angular.element('body').append(el);
@@ -126,8 +126,8 @@ describe('mwCollapsable', function () {
 
     it('sets max-height when element is opened when transcluded element has padding', function () {
       var transcludedContent = '<div id="testContent" style="padding: 100px">TEXTTEXTTEXTTEXTTEXTTEXTTEXTTEXT</div>';
-      collapsable = '<div mw-collapsable="opened" mw-title="TITLE">' + transcludedContent + '</div>';
-      scope.opened = false;
+      collapsable = '<div mw-collapsable="closed" mw-title="TITLE">' + transcludedContent + '</div>';
+      scope.closed = true;
 
       el = $compile(collapsable)(scope);
       angular.element('body').append(el);
@@ -142,8 +142,8 @@ describe('mwCollapsable', function () {
     it('sets max-height when element is opened when multiple elements are transcluded', function () {
       var transcludedContent1 = '<div id="testContent1">TEXTTEXTTEXTTEXTTEXTTEXTTEXTTEXT</div>',
         transcludedContent2 = '<div id="testContent2">TEXTTEXTTEXTTEXTTEXTTEXTTEXTTEXT</div>';
-      collapsable = '<div mw-collapsable="opened" mw-title="TITLE">' + transcludedContent1 + transcludedContent2 + '</div>';
-      scope.opened = false;
+      collapsable = '<div mw-collapsable="closed" mw-title="TITLE">' + transcludedContent1 + transcludedContent2 + '</div>';
+      scope.closed = true;
 
       el = $compile(collapsable)(scope);
       angular.element('body').append(el);
@@ -159,8 +159,8 @@ describe('mwCollapsable', function () {
     it('sets max-height when element is opened when multiple elements are transcluded and one of them is hidden', function () {
       var transcludedContent1 = '<div id="testContent1">TEXTTEXTTEXTTEXTTEXTTEXTTEXTTEXT</div>',
         transcludedContent2 = '<div id="testContent2" style="display: none">TEXTTEXTTEXTTEXTTEXTTEXTTEXTTEXT</div>';
-      collapsable = '<div mw-collapsable="opened" mw-title="TITLE">' + transcludedContent1 + transcludedContent2 + '</div>';
-      scope.opened = false;
+      collapsable = '<div mw-collapsable="closed" mw-title="TITLE">' + transcludedContent1 + transcludedContent2 + '</div>';
+      scope.closed = true;
 
       el = $compile(collapsable)(scope);
       angular.element('body').append(el);
@@ -177,8 +177,8 @@ describe('mwCollapsable', function () {
       var margin = 10,
         transcludedContent1 = '<div id="testContent1" style="margin: ' + margin + 'px">TEXTTEXTTEXTTEXTTEXTTEXTTEXTTEXT</div>',
         transcludedContent2 = '<div id="testContent2" style="margin: ' + margin + 'px">TEXTTEXTTEXTTEXTTEXTTEXTTEXTTEXT</div>';
-      collapsable = '<div mw-collapsable="opened" mw-title="TITLE">' + transcludedContent1 + transcludedContent2 + '</div>';
-      scope.opened = false;
+      collapsable = '<div mw-collapsable="closed" mw-title="TITLE">' + transcludedContent1 + transcludedContent2 + '</div>';
+      scope.closed = true;
 
       el = $compile(collapsable)(scope);
       angular.element('body').append(el);
@@ -193,8 +193,8 @@ describe('mwCollapsable', function () {
 
     it('extends its height when its opened', function(){
       var transcludedContent = '<div id="testContent">TEXTTEXTTEXTTEXTTEXTTEXTTEXTTEXT</div>';
-      collapsable = '<div mw-collapsable="opened" mw-title="TITLE">' + transcludedContent + '</div>';
-      scope.opened = false;
+      collapsable = '<div mw-collapsable="closed" mw-title="TITLE">' + transcludedContent + '</div>';
+      scope.closed = true;
 
       el = $compile(collapsable)(scope);
       angular.element('body').append(el);

--- a/src/mw-ui-components/directives/templates/mw_collapsible.html
+++ b/src/mw-ui-components/directives/templates/mw_collapsible.html
@@ -9,6 +9,7 @@
   </div>
 
   <div class="mw-collapsible-body mw-collapsible-animate margin-top-5"
-       ng-class="{'is-collapsed': isCollapsed}"
-       ng-transclude></div>
+       ng-class="{'is-collapsed': isCollapsed}">
+    <div ng-transclude class="collapsed-content"></div>
+  </div>
 </div>


### PR DESCRIPTION
Fix #136 by enforcing remove max-height after a timeout. 

When initial content was undefined during initialisation the max-height was set to 0 and not removed. 
Fixed this by making sure that max-height is always removed even though the transition end event was not triggered


