### PR TITLE
Fix #159: reset offset when reseting filter

### DIFF
--- a/src/mw-backbone/collection/filterable.js
+++ b/src/mw-backbone/collection/filterable.js
@@ -37,11 +37,6 @@ mwUI.Backbone.Filterable = function (collectionInstance, options) {
       options.params.filter = filter;
     }
 
-    //reset pagination if filter values change
-    if (this.hasFilterChanged(filter)) {
-      _page = 1;
-    }
-
     // Pagination functionality
     if (_perPage && _page && (_limit || _.isUndefined(_limit))) {
       options.params.limit = _perPage;
@@ -160,7 +155,7 @@ mwUI.Backbone.Filterable = function (collectionInstance, options) {
         this.filterValues[key] = value;
         var filterValue = {};
         filterValue[key] = value;
-        if(_.isUndefined(options.silent) || !options.silent){
+        if (_.isUndefined(options.silent) || !options.silent) {
           collectionInstance.trigger('change:filterValue', filterValue);
         }
       } else {
@@ -168,7 +163,7 @@ mwUI.Backbone.Filterable = function (collectionInstance, options) {
       }
     }, this);
 
-    this.setPage(1);
+    this.resetPagination();
     this.filterIsSet = true;
   };
 
@@ -181,7 +176,12 @@ mwUI.Backbone.Filterable = function (collectionInstance, options) {
   this.resetFilters = function () {
     this.filterValues = _getClone(_initialFilterValues);
     this.customUrlParams = _customUrlParams;
+    this.resetPagination();
     this.filterIsSet = false;
+  };
+
+  this.resetPagination = function () {
+    this.setPage(options.page || 1);
   };
 
   (function _main() {

--- a/src/mw-backbone/collection/filterable_test.js
+++ b/src/mw-backbone/collection/filterable_test.js
@@ -215,6 +215,30 @@ describe('Filterable', function () {
 
       expect(filterable.getRequestParams().offset).toBe((100 - 1) * 30);
     });
+
+    it('resets offset when calling setFilters', function () {
+      var filterable = new this.Filterable(this.collection, {
+        filterValues: {
+          test: 'xxx'
+        }
+      });
+      filterable.setPage(100);
+
+      filterable.setFilters({
+        test: 'x'
+      });
+
+      expect(filterable.getRequestParams().offset).toBe(0);
+    });
+
+    it('resets offset when calling resetFilters', function () {
+      var filterable = new this.Filterable(this.collection);
+      filterable.setPage(100);
+
+      filterable.resetFilters();
+
+      expect(filterable.getRequestParams().offset).toBe(0);
+    });
   });
 
   describe('sorting', function () {


### PR DESCRIPTION
Reset pagination when calling reset filter. When clicking on "All items" the filter is reset but the pafgination wasn't reset therefore the backend was asked for items with the previous offset and therefore the resultset was wrong. 

Make sure to update to the latest `mcapjs-client` master version as well 