### PR TITLE
add option to provide an icon and/or tooltip

### DIFF
--- a/src/mw-ui-components/directives/mw_collapsible.js
+++ b/src/mw-ui-components/directives/mw_collapsible.js
@@ -6,7 +6,9 @@ angular.module('mwUI.UiComponents')
       transclude: true,
       scope: {
         isCollapsed: '=mwCollapsable',
-        title: '@mwTitle'
+        title: '@mwTitle',
+        tooltip: '@',
+        icon: '@'
       },
       templateUrl: 'uikit/mw-ui-components/directives/templates/mw_collapsible.html',
       link: function (scope, el) {

--- a/src/mw-ui-components/directives/mw_collapsible.js
+++ b/src/mw-ui-components/directives/mw_collapsible.js
@@ -7,8 +7,8 @@ angular.module('mwUI.UiComponents')
       scope: {
         isCollapsed: '=mwCollapsable',
         title: '@mwTitle',
-        tooltip: '@',
-        icon: '@'
+        tooltip: '@?',
+        icon: '@?'
       },
       templateUrl: 'uikit/mw-ui-components/directives/templates/mw_collapsible.html',
       link: function (scope, el) {

--- a/src/mw-ui-components/directives/templates/mw_collapsible.html
+++ b/src/mw-ui-components/directives/templates/mw_collapsible.html
@@ -5,6 +5,8 @@
        ng-class="{'fa-rotate-90': !isCollapsed}"></i>
     <span class="mw-collapsible-heading-text">
       {{title}}
+      <span ng-if="icon" mw-icon="{{icon}}" tooltip="{{tooltip}}"></span>
+      <span ng-if="tooltip && !icon" mw-icon="mwUI.questionCircle" tooltip="{{tooltip}}"></span>
     </span>
   </div>
 


### PR DESCRIPTION
Fix #157. 
Set attribute `tooltip` to display a tooltip for the collapsible. If you want to have a custom icon you can also set the option `icon`
```html
<div mw-collapsable="true" mw-title="Title" tooltip="ABC DEF"> <!-- for helper tooltip -->
```
```html
<div mw-collapsable="true" mw-title="Title" tooltip="ABC DEF" icon="fa-taxi"><!-- for helper tooltip with a taxi as icon -->
```

