### PR TITLE
Fix #156 Handle invalid filters

### DIFF
--- a/src-relution/mw-ui-rln-i18n/de_DE.json
+++ b/src-relution/mw-ui-rln-i18n/de_DE.json
@@ -7,6 +7,14 @@
       "invalidMimeType": "Die hochgeladene Datei ist ungültig. Der vorgegebene Mime-Type is {{mimeType}}",
       "abort": "Upload abbrechen",
       "uploading": "{{fileName}} wird hochgeladen..."
+    },
+    "mwSidebar": {
+      "invalidFilterModal": {
+        "title": "Der Filter ist nicht mehr gültig",
+        "description": "Der Filter \"{{name}}\" enthält Filter Attribute die entweder nicht mehr verfügbar sind oder geändert wurden. Der Filter kann daher nicht mehr verwendet werden. Sie können den Filter entweder bearbeiten, sodass dieser wieder verwendet werden kann oder löschen.",
+        "delete": "Filter löschen",
+        "modify": "Filter bearbeiten"
+      }
     }
   }
 }

--- a/src-relution/mw-ui-rln-i18n/de_DE.json
+++ b/src-relution/mw-ui-rln-i18n/de_DE.json
@@ -1,5 +1,6 @@
 {
   "rlnUikit": {
+    "cancel": "Abbrechen",
     "mwFileUpload": {
       "dropFiles": "Datei hier hin ziehen um diese hochzuladen",
       "upload": "Datei auswählen",

--- a/src-relution/mw-ui-rln-i18n/en_US.json
+++ b/src-relution/mw-ui-rln-i18n/en_US.json
@@ -7,6 +7,14 @@
       "invalidMimeType": "The uploaded file is invalid. Mime-Type has to be {{mimeType}}",
       "abort": "Abort upload",
       "uploading": "Uploading {{fileName}}..."
+    },
+    "mwSidebar": {
+      "invalidFilterModal": {
+        "title": "The filter is invalid",
+        "description": "The filter \"{{name}}\" contains filter attributes that are either not available anymore or have been changed. Therefore the filter does not work anymore. You can either modify the filter to make it work again or delete it.",
+        "delete": "Delete filter",
+        "modify": "Modify filter"
+      }
     }
   }
 }

--- a/src-relution/mw-ui-rln-i18n/en_US.json
+++ b/src-relution/mw-ui-rln-i18n/en_US.json
@@ -1,5 +1,6 @@
 {
   "rlnUikit": {
+    "cancel": "Cancel",
     "mwFileUpload": {
       "dropFiles": "Drop your file here to upload it",
       "upload": "Select file",

--- a/src-relution/mwSidebarBb.js
+++ b/src-relution/mwSidebarBb.js
@@ -253,6 +253,7 @@ angular.module('mwSidebarBb', [])
     $scope.delete = function () {
       if ($scope.filterModel) {
         $scope.filterModel.destroy();
+        $scope.hideModal();
       } else {
         throw new Error('[InvalidFilterModal] The scope attribute filterModel has to be a valid filterModel. Set it via modal.setScopeAttributes({filterModel:...})');
       }

--- a/src-relution/mwSidebarBb.js
+++ b/src-relution/mwSidebarBb.js
@@ -196,6 +196,34 @@ angular.module('mwSidebarBb', [])
     };
   })
 
+  .factory('InvalidFilterModal', function (Modal) {
+    return Modal.prepare({
+      templateUrl: 'uikit/templates/mwSidebarBb/mwInvalidFilterModal.html',
+      controller: 'InvalidFilterModalController',
+      dismissible: false
+    });
+  })
+
+  .controller('InvalidFilterModalController', function ($scope) {
+    $scope.modify = function () {
+      if (typeof $scope.modifyAction === 'function') {
+        $scope.modifyAction();
+        $scope.hideModal();
+      } else {
+        throw new Error('[InvalidFilterModal] modifyAction has to be a function. Set callback function via modal.setScopeAttributes({modifyAction:...}');
+      }
+    };
+
+    // User really wants to navigate to that page which was saved before in a temp variable
+    $scope.delete = function () {
+      if ($scope.filterModel) {
+        $scope.filterModel.destroy();
+      } else {
+        throw new Error('[InvalidFilterModal] The scope attribute filterModel has to be a valid filterModel. Set it via modal.setScopeAttributes({filterModel:...})');
+      }
+    };
+  })
+
   /**
    * @ngdoc directive
    * @name mwSidebar.directive:mwSidebarSelect

--- a/src-relution/styles/src/_mw-sidebar-filters.scss
+++ b/src-relution/styles/src/_mw-sidebar-filters.scss
@@ -164,7 +164,7 @@
       > a.btn{
         width: calc(100% - 40px);
         clear: both;
-        
+
         *[mw-icon]{
           display: block;
           float: left;
@@ -190,6 +190,18 @@
           height: 100%;
           width: 2px;
           background: #fff;
+        }
+      }
+
+      &.invalid{
+        color: $brand-danger !important;
+        a, a i{
+          color: $brand-danger !important;
+        }
+
+        .invalid-icon{
+          float: none !important;
+          display: inline !important;
         }
       }
 

--- a/src-relution/templates/mwSidebarBb/mwInvalidFilterModal.html
+++ b/src-relution/templates/mwSidebarBb/mwInvalidFilterModal.html
@@ -1,0 +1,19 @@
+<div mw-modal
+     title="{{'rlnUikit.mwSidebar.invalidFilterModal.title' | i18n}}">
+  <div mw-modal-body>
+    <p>
+      {{'rlnUikit.mwSidebar.invalidFilterModal.description' | i18n:{name: filterModel.get('name')} }}
+    </p>
+  </div>
+
+  <div mw-modal-footer>
+    <button type="button"
+            class="btn btn-danger"
+            ng-click="delete()">{{'rlnUikit.mwSidebar.invalidFilterModal.delete' | i18n }}
+    </button>
+    <button type="button"
+            class="btn btn-primary"
+            ng-click="modify()">{{'rlnUikit.mwSidebar.invalidFilterModal.modify' | i18n }}
+    </button>
+  </div>
+</div>

--- a/src-relution/templates/mwSidebarBb/mwInvalidFilterModal.html
+++ b/src-relution/templates/mwSidebarBb/mwInvalidFilterModal.html
@@ -8,6 +8,10 @@
 
   <div mw-modal-footer>
     <button type="button"
+            class="btn btn-default"
+            data-dismiss="modal">{{'rlnUikit.cancel' | i18n }}
+    </button>
+    <button type="button"
             class="btn btn-danger"
             ng-click="delete()">{{'rlnUikit.mwSidebar.invalidFilterModal.delete' | i18n }}
     </button>

--- a/src-relution/templates/mwSidebarBb/mwSidebarFilters.html
+++ b/src-relution/templates/mwSidebarBb/mwSidebarFilters.html
@@ -27,6 +27,7 @@
         </div>
       </li>
       <li ng-repeat="filter in filters.models"
+          ng-if="!(filter.get('invalid') && !filter.canModifyFilter())"
           ng-class="{'active':isFilterApplied(filter), 'invalid': filter.get('invalid')}"
           class="filter">
         <a href="#"

--- a/src-relution/templates/mwSidebarBb/mwSidebarFilters.html
+++ b/src-relution/templates/mwSidebarBb/mwSidebarFilters.html
@@ -27,7 +27,7 @@
         </div>
       </li>
       <li ng-repeat="filter in filters.models"
-          ng-class="{'active':isFilterApplied(filter)}"
+          ng-class="{'active':isFilterApplied(filter), 'invalid': filter.get('invalid')}"
           class="filter">
         <a href="#"
            mw-prevent-default="click"
@@ -40,9 +40,13 @@
                 mw-icon="fa-lock"
                 tooltip="{{'common.filterIsPrivate' | i18n}}"></span>
           <span class="filter-name">{{filter.get('name')}}</span>
+          <span ng-if="filter.get('invalid')"
+                class="invalid-icon"
+                mw-icon="mwUI.warning"
+                tooltip="{{'rlnUikit.mwSidebar.invalidFilterModal.description' | i18n:{name: filter.get('name')} }}"></span>
         </a>
 
-        <div ng-if="appliedFilter.id===filter.id"
+        <div ng-if="appliedFilter.id===filter.id || filter.get('invalid')"
              class="pull-right action-btns hidden-xs hidden-sm">
 
           <div ng-if="!isLoading && filter.canModifyFilter()">

--- a/src/mw-backbone/collection/filterable.js
+++ b/src/mw-backbone/collection/filterable.js
@@ -147,19 +147,31 @@ mwUI.Backbone.Filterable = function (collectionInstance, options) {
     return _sortOrder;
   };
 
+  this.getInvalidFilterKeys = function (filterMap) {
+    var invalidFilterKeys = [];
+    _.forEach(filterMap, function (value, key) {
+      if (!_.has(this.filterValues, key)) {
+        invalidFilterKeys.push(key);
+      }
+    }.bind(this));
+    return invalidFilterKeys;
+  };
+
   this.setFilters = function (filterMap, options) {
     options = options || {};
 
+    var invalidFilterKeys = this.getInvalidFilterKeys(filterMap);
+
+    if (invalidFilterKeys.length > 0) {
+      throw new Error('[mwFilterable] The filter keys \'' + invalidFilterKeys.join(',') + '\' do not exist, did you add them to filterValues of the model?');
+    }
+
     _.forEach(filterMap, function (value, key) {
-      if (_.has(this.filterValues, key)) {
-        this.filterValues[key] = value;
-        var filterValue = {};
-        filterValue[key] = value;
-        if (_.isUndefined(options.silent) || !options.silent) {
-          collectionInstance.trigger('change:filterValue', filterValue);
-        }
-      } else {
-        throw new Error('Filter named \'' + key + '\' not found, did you add it to filterValues of the model?');
+      this.filterValues[key] = value;
+      var filterValue = {};
+      filterValue[key] = value;
+      if (_.isUndefined(options.silent) || !options.silent) {
+        collectionInstance.trigger('change:filterValue', filterValue);
       }
     }, this);
 


### PR DESCRIPTION
Invalid filters are now highlighted in the filter sidebar. When the user tries to use and invalid filter a modal is displayed where the user can either modify or delete the filter

**As a precondition the portal MR #1049 has to be accepted in GitLab**