### PR TITLE
Feature/improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# v1.21.0
+## Features
+### Backbone module
+- Trigger Backbone model/collection sync events (`request`, `sync`, `error` ) 
+when calling `model.request` or `collection.request
+- Set property `isSynchronising` on model/collection on request and unset it when its done
+
+### Ui components module
+- `mw-view-change-loader` can be set manually by triggering rootscope events 
+`$showViewChangeLoader` and `$hideViewChangeLoader`
+- `mwTabPane` was extended with scope property `id` and its possible to select a tab pane from `mwTabBar` by 
+setting scope property `activePaneNumber`
+- Transcluded content from `mwTabPane` is removed when tab is not selected anymore
+
+### Layout module
+- Add `backdrop-filter`to `mwHeader` to blur content beneath it (works only in safari so far)
+
+## Bug Fixes
+### Utils module
+- Fix mwUrlStorage so it also removes query params from url when they were set to `options.removeOnUrlChange` and remove is called
+
 # v1.20.1
 ## Features
 ### List module

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mw-uikit",
   "description": "A toolbox to build portals with AngularJS 1.5.x that have a lot of forms and list views for example admin portals to manage data.",
   "author": "Alexander Zarges <a.zarges@mwaysolutions.com> (http://relution.io)",
-  "version": "1.20.1",
+  "version": "1.21.0",
   "license": "Apache-2.0",
   "devDependencies": {
     "angular": "1.5.7",

--- a/src-relution/mwSidebarBb.js
+++ b/src-relution/mwSidebarBb.js
@@ -384,11 +384,13 @@ angular.module('mwSidebarBb', [])
         customUrlParameter: '@'
       },
       templateUrl: 'uikit/templates/mwSidebarBb/mwSidebarInput.html',
-      link: function (scope, elm, attr, ctrl) {
+      link: function (scope, elm, attr, mwSidebarFiltersBbCtrl) {
 
         scope.viewModel = {};
 
         scope._type = scope.type || 'text';
+
+        scope.collection = mwSidebarFiltersBbCtrl.getCollection();
 
         scope.isValid = function () {
           return elm.find('input').first().hasClass('ng-valid');
@@ -396,8 +398,16 @@ angular.module('mwSidebarBb', [])
 
         scope.changed = function () {
           var property = scope.customUrlParameter ? scope.customUrlParameter : scope.property;
-          ctrl.changeFilter(property, scope.viewModel.val, !!scope.customUrlParameter);
+          mwSidebarFiltersBbCtrl.changeFilter(property, scope.viewModel.val, !!scope.customUrlParameter);
         };
+
+        scope.$watch('collection.filterable.filterValues.' + scope.property, function (val) {
+          if (val && val.length > 0) {
+            scope.viewModel.val = val;
+          } else {
+            scope.viewModel.val = null;
+          }
+        });
       }
     };
   })

--- a/src/mw-backbone/mw_backbone_config.js
+++ b/src/mw-backbone/mw_backbone_config.js
@@ -14,15 +14,27 @@ Backbone.ajax = function (options) {
   if (mwUI.Backbone.use$http && _$http) {
     // Set HTTP Verb as 'method'
     options.method = options.type;
+
+    //Trigger sync event in case backbone.ajax is called manually and not by model/collection
+    if(!options.success && !options.error && options.instance){
+      options.instance.trigger('request');
+    }
+
     // Use angulars $http implementation for requests
     return _$http.apply(angular, arguments).then(function(resp){
       if (options.success && typeof options.success === 'function') {
         options.success(resp);
+      } else if(options.instance){
+        //Trigger success event in case backbone.ajax is called manually and not by model/collection
+        options.instance.trigger('sync');
       }
       return resp;
     }, function(resp){
       if (options.error && typeof options.error === 'function') {
         options.error(resp);
+      } else if(options.instance){
+        //Trigger error event in case backbone.ajax is called manually and not by model/collection
+        options.instance.trigger('error');
       }
       return _$q.reject(resp);
     });

--- a/src/mw-layout/styles/_mw_header.scss
+++ b/src/mw-layout/styles/_mw_header.scss
@@ -58,6 +58,8 @@ div[mw-header] {
     -webkit-align-items: center;
     align-items: center;
     border-bottom: 1px solid #e7e7e7;
+    backdrop-filter: blur(5px);
+    -webkit-backdrop-filter: blur(5px);
 
     .back-btn {
       margin-right: $headerIconMargin;

--- a/src/mw-ui-components/directives/mw_collapsible.js
+++ b/src/mw-ui-components/directives/mw_collapsible.js
@@ -26,6 +26,7 @@ angular.module('mwUI.UiComponents')
 
         var removeMaxHeight = function () {
           collapsedBody.css('max-height', 'initial');
+          collapsedBody.css('overflow', 'initial');
           collapsedBody.off('transitionend', removeMaxHeight);
         };
 
@@ -44,6 +45,7 @@ angular.module('mwUI.UiComponents')
           collapsedBody.off('transitionend', removeMaxHeight);
           collapsedBody.css('max-height', getHeight());
           $timeout(function () {
+            collapsedBody.css('overflow', 'hidden');
             collapsedBody.css('max-height', 0);
           }, 5);
           scope.isCollapsed = true;

--- a/src/mw-ui-components/directives/mw_tab_bar.js
+++ b/src/mw-ui-components/directives/mw_tab_bar.js
@@ -25,14 +25,22 @@ angular.module('mwUI.UiComponents')
       templateUrl: 'uikit/mw-ui-components/directives/templates/mw_tab_bar.html',
       controller: function ($scope) {
         var panes = $scope.panes = [],
-          activeNumber;
+          activePaneIndex;
 
         var setInitialSelection = function () {
-          activeNumber = null;
-          if (angular.isUndefined($scope.activePaneNumber) && angular.isUndefined($scope.activePaneId)) {
+          activePaneIndex = null;
+
+          // In case that no active pane is defined by setting activePaneNumber or Id the first pane will be selected
+          if (angular.isUndefined($scope.activePaneNumber) && angular.isUndefined($scope.activePaneId) && panes.length>0) {
             $scope.select(panes[0]);
+
+          // When a pane number is defined the pane with the index of activePaneNumber + 1 will be selected
+          // So when the second tab shall be selected set activePaneNumber to 2
           } else if (angular.isDefined($scope.activePaneNumber)) {
             $scope.selectTabByNumber($scope.activePaneNumber);
+
+          // When a pane id is defined the pane where the pane id equals the activePaneId will be selected
+          // Make sure to set an id on the mw-tab-pane
           } else if (angular.isDefined($scope.activePaneId)) {
             $scope.selectTabById($scope.activePaneId);
           }
@@ -53,19 +61,19 @@ angular.module('mwUI.UiComponents')
         };
 
         $scope.select = function (newPane) {
-          var newActivePaneNumber = _.indexOf($scope.panes, newPane) + 1;
+          var newPaneIndex = _.indexOf($scope.panes, newPane);
 
-          if (newPane && newActivePaneNumber > 0 && newActivePaneNumber !== activeNumber) {
+          if (newPane && newPaneIndex !== -1 && newPaneIndex !== activePaneIndex) {
             var previousSelectedPane = $scope.getActivePane();
             if (previousSelectedPane) {
               previousSelectedPane.deselect();
             }
 
             newPane.select();
-            activeNumber = newActivePaneNumber;
+            activePaneIndex = newPaneIndex;
 
             if ($scope.tabChanged && typeof $scope.tabChanged === 'function') {
-              $scope.tabChanged(activeNumber, newPane, previousSelectedPane);
+              $scope.tabChanged(activePaneIndex + 1, newPane, previousSelectedPane);
               $rootScope.$emit('$mwTabChange');
             }
           }

--- a/src/mw-ui-components/directives/mw_tab_bar.js
+++ b/src/mw-ui-components/directives/mw_tab_bar.js
@@ -1,61 +1,118 @@
 angular.module('mwUI.UiComponents')
-  //TODO rename
-  /**
-   * @example ```html
-   * <!-- change callback example -->
-   * <div mw-tabs active-pane-number="myCtrl.activePane" tab-changed="myCtrl.tabChanged">
-      <div mw-tabs-pane="{{'mytitle'| i18n}}">
-      Tab 1
-      </div>
-      <div mw-tabs-pane="{{'mytitle_2'| i18n}}">
-      Tab 2
-      </div>
-    </div>
-   * ```
-   */
-  .directive('mwTabs', function () {
+//TODO rename
+/**
+ * @example ```html
+ * <!-- change callback example -->
+ * <div mw-tabs active-pane-number="myCtrl.activePane" tab-changed="myCtrl.tabChanged">
+ <div mw-tabs-pane="{{'mytitle'| i18n}}">
+ Tab 1
+ </div>
+ <div mw-tabs-pane="{{'mytitle_2'| i18n}}">
+ Tab 2
+ </div>
+ </div>
+ * ```
+ */
+  .directive('mwTabs', function ($rootScope) {
     return {
       transclude: true,
       scope: {
-        justified: '=',
-        activePaneNumber: '=',
-        tabChanged: '='
+        justified: '=?',
+        activePaneNumber: '=?',
+        activePaneId: '@?',
+        tabChanged: '=?'
       },
       templateUrl: 'uikit/mw-ui-components/directives/templates/mw_tab_bar.html',
       controller: function ($scope) {
-        var panes = $scope.panes = [];
-        $scope.select = function (pane) {
-          angular.forEach(panes, function (p) {
-            p.selected = false;
-          });
+        var panes = $scope.panes = [],
+          activeNumber;
 
-          if($scope.activePaneNumber){
-            $scope.activePaneNumber = _.indexOf($scope.panes,pane)+1;
-          }
-
-          pane.selected = true;
-          // emit the callback
-          if ($scope.tabChanged && typeof $scope.tabChanged === 'function') {
-            $scope.tabChanged($scope.activePaneNumber);
+        var setInitialSelection = function () {
+          activeNumber = null;
+          if (angular.isUndefined($scope.activePaneNumber) && angular.isUndefined($scope.activePaneId)) {
+            $scope.select(panes[0]);
+          } else if (angular.isDefined($scope.activePaneNumber)) {
+            $scope.selectTabByNumber($scope.activePaneNumber);
+          } else if (angular.isDefined($scope.activePaneId)) {
+            $scope.selectTabById($scope.activePaneId);
           }
         };
-        
-        // add a change listener on the pane 
-        if ($scope.tabChanged && typeof $scope.tabChanged === 'function') { 
-          $scope.$watch('activePaneNumber', function (_new, _old) {
-            if (_new !== _old) {
-              $scope.select(panes[_new - 1]);
+
+        var throttledSetInitialSelection = _.debounce(setInitialSelection, 100);
+
+        $scope.getActivePane = function () {
+          var activePane;
+          $scope.panes.every(function (pane) {
+            if (pane.isSelected()) {
+              activePane = pane;
+              return false;
             }
+            return true;
           });
-        }
+          return activePane;
+        };
+
+        $scope.select = function (newPane) {
+          var newActivePaneNumber = _.indexOf($scope.panes, newPane) + 1;
+
+          if (newPane && newActivePaneNumber > 0 && newActivePaneNumber !== activeNumber) {
+            var previousSelectedPane = $scope.getActivePane();
+            if (previousSelectedPane) {
+              previousSelectedPane.deselect();
+            }
+
+            newPane.select();
+            activeNumber = newActivePaneNumber;
+
+            if ($scope.tabChanged && typeof $scope.tabChanged === 'function') {
+              $scope.tabChanged(activeNumber, newPane, previousSelectedPane);
+              $rootScope.$emit('$mwTabChange');
+            }
+          }
+        };
+
+        $scope.selectTabByNumber = function (number) {
+          if (number > 0 && number <= $scope.tabs.length) {
+            $scope.select(panes[number - 1]);
+          }
+        };
+
+        $scope.selectTabById = function (id) {
+          $scope.panes.every(function (pane) {
+            if (pane.getId() === id) {
+              $scope.select(pane);
+              return false;
+            }
+            return true;
+          });
+        };
+
+        // add a change listener on the pane
+        $scope.$watch('activePaneNumber', function (_new, _old) {
+          if (_new && _new !== _old) {
+            $scope.selectTabByNumber(_new);
+          }
+        });
+
+        $scope.$watch('activePaneId', function (_newId) {
+          if (_newId) {
+            $scope.selectTabById(_newId);
+          }
+        });
 
         this.registerPane = function (pane) {
-          if ( ( $scope.activePaneNumber && $scope.activePaneNumber-1 === panes.length) || (!panes.length && !$scope.activePaneNumber) ) {
-            var bak = $scope.activePaneNumber;
-            $scope.select(pane);
-            $scope.activePaneNumber = bak;
-          }
           panes.push(pane);
+          throttledSetInitialSelection();
+        };
+
+        this.unRegisterPane = function (pane) {
+          if (pane) {
+            var indexOfExistingPane = _.indexOf(panes, pane);
+            if (indexOfExistingPane !== -1) {
+              $scope.panes.splice(indexOfExistingPane, 1);
+            }
+            throttledSetInitialSelection();
+          }
         };
       }
     };

--- a/src/mw-ui-components/directives/mw_tab_bar.js
+++ b/src/mw-ui-components/directives/mw_tab_bar.js
@@ -24,6 +24,8 @@ angular.module('mwUI.UiComponents')
       },
       templateUrl: 'uikit/mw-ui-components/directives/templates/mw_tab_bar.html',
       controller: function ($scope) {
+        // The panes are populated by the mw-tabs-pane directive that is calling `registerPane`of this controller
+        // It is defined as a scope attribute so it is available in this html template
         var panes = $scope.panes = [],
           activePaneIndex;
 

--- a/src/mw-ui-components/directives/mw_tab_pane.js
+++ b/src/mw-ui-components/directives/mw_tab_pane.js
@@ -4,15 +4,15 @@ angular.module('mwUI.UiComponents')
     return {
       scope: {
         title: '@mwTabsPane',
-        id: '@',
-        icon: '@',
-        tooltip: '@',
-        isInvalid: '=',
-        badge: '@'
+        id: '@?',
+        icon: '@?',
+        tooltip: '@?',
+        badge: '@?',
+        isInvalid: '=?'
       },
       transclude: true,
       replace: true,
-      require: '^mwTabs',
+      require: ['^mwTabs', '^?form'],
       templateUrl: 'uikit/mw-ui-components/directives/templates/mw_tab_pane.html',
       controller: function ($scope) {
         var selected = false;

--- a/src/mw-ui-components/directives/mw_tab_pane.js
+++ b/src/mw-ui-components/directives/mw_tab_pane.js
@@ -1,19 +1,45 @@
 angular.module('mwUI.UiComponents')
-  //TODO rename
+//TODO rename
   .directive('mwTabsPane', function () {
     return {
       scope: {
         title: '@mwTabsPane',
+        id: '@',
         icon: '@',
         tooltip: '@',
-        isInvalid: '='
+        isInvalid: '=',
+        badge: '@'
       },
       transclude: true,
       replace: true,
       require: '^mwTabs',
       templateUrl: 'uikit/mw-ui-components/directives/templates/mw_tab_pane.html',
-      link: function (scope, elm, attr, mwTabsCtrl) {
+      controller: function ($scope) {
+        var selected = false;
+        $scope.getId = function () {
+          return $scope.id || $scope.$id;
+        };
+
+        $scope.deselect = function () {
+          selected = false;
+        };
+
+        $scope.select = function () {
+          selected = true;
+        };
+
+        $scope.isSelected = function () {
+          return selected;
+        };
+      },
+      link: function (scope, el, attr, mwTabsCtrl) {
         mwTabsCtrl.registerPane(scope);
+
+        scope.$on('$destroy', function () {
+          el.remove();
+          scope.deselect();
+          mwTabsCtrl.unRegisterPane(scope);
+        });
       }
     };
   });

--- a/src/mw-ui-components/directives/mw_tab_pane.js
+++ b/src/mw-ui-components/directives/mw_tab_pane.js
@@ -32,7 +32,10 @@ angular.module('mwUI.UiComponents')
           return selected;
         };
       },
-      link: function (scope, el, attr, mwTabsCtrl) {
+      link: function (scope, el, attr, ctrls) {
+        var mwTabsCtrl = ctrls[0],
+            formCtrl = ctrls[1];
+
         mwTabsCtrl.registerPane(scope);
 
         scope.$on('$destroy', function () {
@@ -40,6 +43,14 @@ angular.module('mwUI.UiComponents')
           scope.deselect();
           mwTabsCtrl.unRegisterPane(scope);
         });
+
+        // Do not use ng-if to remove the transcluded tab pane content when the tab pane is in a `Form`
+        // Validation does not work when the content is removed from the dom
+        // When you have a tab bar with multiple tabs and each tab contains required input, the tab pane content
+        // must be always in the dom so the form controller knows that the inputs are existing
+        scope.canUseNgIf = function(){
+          return !formCtrl;
+        };
       }
     };
   });

--- a/src/mw-ui-components/directives/mw_view_change_loader.js
+++ b/src/mw-ui-components/directives/mw_view_change_loader.js
@@ -9,6 +9,14 @@ angular.module('mwUI.UiComponents')
           loading: false
         };
 
+        var showLoaderListener = $rootScope.$on('$showViewChangeLoader', function () {
+          scope.viewModel.loading = true;
+        });
+
+        var hideLoaderListener = $rootScope.$on('$hideViewChangeLoader', function () {
+          scope.viewModel.loading = false;
+        });
+
         var locationChangeSuccessListener = $rootScope.$on('$locationChangeSuccess', function () {
           if(!routeUpdateInProgress){
             scope.viewModel.loading = true;
@@ -34,6 +42,8 @@ angular.module('mwUI.UiComponents')
           routeChangeSuccessListener();
           routeChangeErrorListener();
           routeChangeUpdateListener();
+          showLoaderListener();
+          hideLoaderListener();
         });
       }
     };

--- a/src/mw-ui-components/directives/templates/mw_indefinite_loading.html
+++ b/src/mw-ui-components/directives/templates/mw_indefinite_loading.html
@@ -1,4 +1,4 @@
-<div class="mw-infinite-loading">
+<div class="mw-infinite-loading row">
   <div class="col-md-12 text-center">
     <div mw-spinner></div>
     <div class="lead">

--- a/src/mw-ui-components/directives/templates/mw_tab_bar.html
+++ b/src/mw-ui-components/directives/templates/mw_tab_bar.html
@@ -4,12 +4,13 @@
   <ul class="nav nav-tabs"
       ng-class="{ 'nav-justified': justified }">
     <li ng-repeat="pane in panes"
-        ng-class="{ active: pane.selected }">
+        ng-class="{ active: pane.isSelected() }">
       <a ng-class="{ 'has-error': pane.isInvalid }"
          ng-click="select(pane)">
         <span ng-if="pane.icon"
               mw-icon="{{pane.icon}}"></span>
         {{ pane.title }}
+        <span ng-if="pane.badge" class="badge badge-default badge-light">{{pane.badge}}</span>
         <span ng-if="pane.tooltip"
               mw-icon="mwUI.questionCircle"
               tooltip="{{pane.tooltip}}"></span>

--- a/src/mw-ui-components/directives/templates/mw_tab_pane.html
+++ b/src/mw-ui-components/directives/templates/mw_tab_pane.html
@@ -1,4 +1,5 @@
 <div class="tab-pane mw-tab-pane"
      role="tabpanel"
-     ng-class="{active: selected}"
-     ng-transclude></div>
+     ng-class="{active: isSelected()}">
+  <div ng-if="isSelected()" ng-transclude></div>
+</div>

--- a/src/mw-ui-components/directives/templates/mw_tab_pane.html
+++ b/src/mw-ui-components/directives/templates/mw_tab_pane.html
@@ -1,5 +1,10 @@
 <div class="tab-pane mw-tab-pane"
      role="tabpanel"
      ng-class="{active: isSelected()}">
-  <div ng-if="isSelected()" ng-transclude></div>
+  <div ng-if="canUseNgIf()">
+    <div ng-if="isSelected()" ng-transclude></div>
+  </div>
+  <div ng-if="!canUseNgIf()">
+    <div ng-show="isSelected()" ng-transclude></div>
+  </div>
 </div>

--- a/src/mw-ui-components/styles/_mw_collapsible.scss
+++ b/src/mw-ui-components/styles/_mw_collapsible.scss
@@ -22,7 +22,6 @@
 
   .mw-collapsible-animate {
     opacity: 1;
-    overflow: hidden;
     -webkit-transition: all ease-in-out 0.5s;
     transition: all ease-in-out 0.5s;
 

--- a/src/mw-ui-components/styles/_mw_indefinite_loading.scss
+++ b/src/mw-ui-components/styles/_mw_indefinite_loading.scss
@@ -1,4 +1,7 @@
 .mw-infinite-loading{
+  margin-top: 15px;
+  margin-bottom: 15px;
+
   .mw-spinner,
   .lead {
     display: inline-block;


### PR DESCRIPTION
- Trigger Backbone model/collection sync events (`request`, `sync`, `error` ) when calling `model.request` or `collection.request
- Set property `isSynchronising` on model/collection on request and unset it when its done
- `mw-view-change-loader` can be set manually by triggering rootscope events `$showViewChangeLoader` and `$hideViewChangeLoader`
- `mwTabPane` was extended with scope property `id` and its possible to select a tab pane from `mwTabBar` by setting scope property `activePaneNumber`
- Transcluded content from `mwTabPane` is removed when tab is not selected anymore
- Add `backdrop-filter`to `mwHeader` to blur content beneath it (works only in safari so far)
- Fix mwUrlStorage so it also removes query params from url when they were set to `options.removeOnUrlChange` and remove is called