### PR TITLE
Feature/url storage history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v1.21.2
+## Features
+### Utils module
+- Urls query params that are set by the `mwUrlStorage` won't be put into the navigation history by default.
+So when calling `mwUrlStorage.setItem('key','value')` it will append the query prams to the url but not create a
+history entry. When using the back button you will be moved to the previous url. If you want to let the user browse 
+through the different query states you can set the options param `keepInHistory`
+`mwUrlStorage.setItem('key','value', {keepInHistory: true})`
+
 # v1.21.1
 ## Bug Fixes
 ### Ui components module

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mw-uikit",
   "description": "A toolbox to build portals with AngularJS 1.5.x that have a lot of forms and list views for example admin portals to manage data.",
   "author": "Alexander Zarges <a.zarges@mwaysolutions.com> (http://relution.io)",
-  "version": "1.21.1",
+  "version": "1.21.2",
   "license": "Apache-2.0",
   "devDependencies": {
     "angular": "1.5.7",

--- a/src-relution/test/mwListCollectionFilter/mwListCollectionFilter.js
+++ b/src-relution/test/mwListCollectionFilter/mwListCollectionFilter.js
@@ -88,7 +88,8 @@ describe('MwListCollectionFilter', function () {
         search: function () {
           $locationSpy.search.apply($locationSpy, arguments);
           return queryParams;
-        }
+        },
+        replace: function(){}
       };
     });
     $provide.service('$route', function () {

--- a/src/mw-utils/services/mw_url_storage.js
+++ b/src/mw-utils/services/mw_url_storage.js
@@ -73,9 +73,25 @@ angular.module('mwUI.Utils')
     });
 
     return {
+      /*
+       * Return the value that is stored in the url for a key
+       *
+       * params:
+       * key: string
+       */
       getItem: function (key) {
         return $location.search()[key];
       },
+      /*
+       * Calls setItem but allows you to set a whole object instead of a key,value
+       *
+       * params:
+       * obj: object
+       * options: {
+       *   removeOnUrlChange: boolean
+       *   keepInHistory: boolean
+       * }
+       */
       setObject: function (obj, options) {
         options = options || {};
         var wasChanged = false;
@@ -93,9 +109,30 @@ angular.module('mwUI.Utils')
         }
 
         if (wasChanged) {
-          setUrlQueryParams(obj);
+          setUrlQueryParams(obj, false, false, options);
         }
       },
+      /*
+       * Save a key value pair as query param in the url
+       * The query will be in the url until you call removeItem('key') also on url change
+       * You don't have to worry about the param it will just stay
+       *
+       * In cases where you don't wan't to keep the query param in the url forever you can set the options param
+       * removeOnUrlChange to true (default is false
+       *
+       * The query won't be stored in the url history so when using the back button you will not go back to the previous
+       * query state but to the previous url
+       * In cases where you want to go to store the query in the history you can set the options param
+       * `keepInHistory` to true
+       *
+       * params:
+       * key: string
+       * value: string
+       * options: {
+       *   removeOnUrlChange: boolean
+       *   keepInHistory: boolean
+       * }
+       */
       setItem: function (key, value, options) {
         options = options || {};
         if (storage[key] !== value) {
@@ -104,9 +141,15 @@ angular.module('mwUI.Utils')
           }
           var obj = {};
           obj[key] = value;
-          setUrlQueryParams(obj);
+          setUrlQueryParams(obj, false, false, options);
         }
       },
+      /*
+       * Calls removeItem but allows you to remove a whole object instead of a key
+       *
+       * params:
+       * obj: object
+       */
       removeObject: function (obj) {
         var wasChanged = false;
         var removeKeys = [];
@@ -128,6 +171,12 @@ angular.module('mwUI.Utils')
           setUrlQueryParams(storage, false, removeKeys);
         }
       },
+      /*
+       * Removes a key with its value from the url
+       *
+       * params:
+       * key: string
+       */
       removeItem: function (key) {
         if (storage[key]) {
           storage[key] = null;
@@ -140,6 +189,10 @@ angular.module('mwUI.Utils')
           return false;
         }
       },
+      /*
+       * Removes all items that have been set by setItem or setObject from the url
+       * Other url query params that have been set e.g. by calling $location.search() won't be affected
+       */
       clear: function () {
         var removeKeys = [];
         for (var key in storage) {

--- a/src/mw-utils/services/mw_url_storage.js
+++ b/src/mw-utils/services/mw_url_storage.js
@@ -34,12 +34,13 @@ angular.module('mwUI.Utils')
     var hasChangedValues = function (params, removeParams) {
       var currentSearchParams = $location.search();
       var changedParams = _.difference(_.values(params), _.values(currentSearchParams));
-      
+
       removeParams = _.difference(_.values(removeParams), _.values(currentSearchParams));
       return changedParams.length > 0 || removeParams.length > 0;
     };
 
-    var setUrlQueryParams = function (params, preferQueryOverStorage, removeKeys) {
+    var setUrlQueryParams = function (params, preferQueryOverStorage, removeKeys, options) {
+      options = options || {};
       if (hasChangedValues(params, removeKeys)) {
         var currentSearchParams = $location.search(),
           newSearchParams;
@@ -58,6 +59,10 @@ angular.module('mwUI.Utils')
 
         preventRouteReload();
         $location.search(newSearchParams);
+
+        if (!options.keepInHistory) {
+          $location.replace();
+        }
       }
     };
 

--- a/src/mw-utils/services/mw_url_storage_test.js
+++ b/src/mw-utils/services/mw_url_storage_test.js
@@ -72,6 +72,7 @@ describe('MwUrlStorageTest', function () {
   afterEach(function () {
     this.queryParams = {};
     this.currentUrl = '';
+    subject.clear();
   });
 
   it('sets query param when calling setItem', function () {

--- a/src/mw-utils/services/mw_url_storage_test.js
+++ b/src/mw-utils/services/mw_url_storage_test.js
@@ -46,11 +46,13 @@ describe('MwUrlStorageTest', function () {
           queryParams = params;
         }
         return queryParams;
-      }
+      },
+      replace: function(){}
     };
     spyOn(locationSpy, 'path').and.callThrough();
     spyOn(locationSpy, 'search').and.callThrough();
     spyOn(locationSpy, 'url').and.callThrough();
+    spyOn(locationSpy, 'replace');
     $provide.value('$location', locationSpy);
 
     routeSpy = {
@@ -76,6 +78,18 @@ describe('MwUrlStorageTest', function () {
     subject.setItem('abc', 'IRRELEVANT');
 
     expect(locationSpy.search).toHaveBeenCalledWith({abc: 'IRRELEVANT'});
+  });
+
+  it('does not create a new navigation history entry when calling setItem', function () {
+    subject.setItem('abc', 'IRRELEVANT');
+
+    expect(locationSpy.replace).toHaveBeenCalled();
+  });
+
+  it('does create a new navigation history entry when calling setItem and keepInHistory is set to true', function () {
+    subject.setItem('abc', 'IRRELEVANT2', {keepInHistory: true});
+
+    expect(locationSpy.replace).not.toHaveBeenCalled();
   });
 
   it('updated query param when calling setItem and a previous value does exist', function () {

--- a/src/mw-utils/services/mw_url_storage_test.js
+++ b/src/mw-utils/services/mw_url_storage_test.js
@@ -88,7 +88,7 @@ describe('MwUrlStorageTest', function () {
   });
 
   it('does create a new navigation history entry when calling setItem and keepInHistory is set to true', function () {
-    subject.setItem('abc', 'IRRELEVANT2', {keepInHistory: true});
+    subject.setItem('abc', 'IRRELEVANT', {keepInHistory: true});
 
     expect(locationSpy.replace).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
Do not store query params that have been set via mwUrlStorage in the navigation history.
Otherwise the user is navigating through the different query param states when using the back button.

If you want to have this behaviour you can set the options param `keepInHistory` to true