### PR TITLE
Fix #182: Menuentry is not hidden when it is removed during menu initialisation

### DIFF
--- a/src/mw-menu/directives/mw_menu_entry.js
+++ b/src/mw-menu/directives/mw_menu_entry.js
@@ -50,6 +50,10 @@ angular.module('mwUI.Menu')
         };
 
         var tryToRegisterAtParent = function () {
+          if (!menuEntry) {
+            return;
+          }
+
           if (parentCtrl) {
             if (!parentCtrl.getMenuEntry()) {
               // TODO could not produce that error. In case the following exception is thrown write a test case and comment line in
@@ -116,6 +120,9 @@ angular.module('mwUI.Menu')
           if (entryHolder) {
             entryHolder.remove(menuEntry);
           }
+
+          menuEntry = null;
+          ctrl.setMenuEntry(menuEntry);
         });
 
         scope.$watchGroup(['id', 'label', 'url', 'icon', 'class', 'order', 'target'], setMenuEntry);

--- a/src/mw-menu/directives/mw_menu_entry_test.js
+++ b/src/mw-menu/directives/mw_menu_entry_test.js
@@ -51,6 +51,17 @@ describe('mwUi menu entry directive', function () {
     expect(this.menu.length).toBe(0);
   });
 
+  it('removes mw-menu-entry when it is removed during initialisation', function () {
+    this.$scope.isVisible = true;
+    this.buildMenuEl('<div mw-menu-entry ng-if="isVisible" label="xxx" url="xxx"></div>');
+    this.$scope.$digest();
+    this.$scope.isVisible = false;
+    this.$scope.$digest();
+    this.$timeout.flush();
+
+    expect(this.menu.length).toBe(0);
+  });
+
   it('sets order by it itself by using the position where it is in the dom and sort entries by it', function () {
     this.buildMenuEl('' +
       '<div mw-menu-entry label="xxx1" url="xxx1"></div>' +


### PR DESCRIPTION
Do not register menuEntry when it has been removed during initialisation