### PR TITLE
Feature/tabbar ng show

### DIFF
--- a/src/mw-ui-components/directives/mw_tab_bar.js
+++ b/src/mw-ui-components/directives/mw_tab_bar.js
@@ -98,6 +98,19 @@ angular.module('mwUI.UiComponents')
           });
         };
 
+        $scope.getActivePaneIndex = function () {
+          if (activePaneIndex) {
+            return activePaneIndex;
+          } else {
+            return 0;
+          }
+        };
+
+        $scope.canShowPaneContent = function () {
+          var activePane = $scope.panes[activePaneIndex];
+          return (activePane && activePane.isInitialised);
+        };
+
         // add a change listener on the pane
         $scope.$watch('activePaneNumber', function (_new, _old) {
           if (_new && _new !== _old) {

--- a/src/mw-ui-components/directives/mw_tab_bar.js
+++ b/src/mw-ui-components/directives/mw_tab_bar.js
@@ -20,7 +20,8 @@ angular.module('mwUI.UiComponents')
         justified: '=?',
         activePaneNumber: '=?',
         activePaneId: '@?',
-        tabChanged: '=?'
+        tabChanged: '=?',
+        removeInactiveContent: '=?'
       },
       templateUrl: 'uikit/mw-ui-components/directives/templates/mw_tab_bar.html',
       controller: function ($scope) {
@@ -137,6 +138,10 @@ angular.module('mwUI.UiComponents')
             }
             throttledSetInitialSelection();
           }
+        };
+
+        this.canRemoveInactiveContent = function(){
+          return $scope.removeInactiveContent;
         };
       }
     };

--- a/src/mw-ui-components/directives/mw_tab_bar.js
+++ b/src/mw-ui-components/directives/mw_tab_bar.js
@@ -1,16 +1,32 @@
 angular.module('mwUI.UiComponents')
 //TODO rename
 /**
+ * @ngdoc directive
+ * @name mwUI.UiComponents.directive:mwTabs
+ *
+ * @description Shows a tab view. Requires that you transclude mw-tabs-pane. They define the title, icon, etc of the tab
+ * When setting removeInactiveContent so true it will remove the tab content of inactive tabs from the dom. This is
+ * recommended for tab content that has a complex logic
+ *
+ * @param {justified} boolean defines the arrangement of the tabs. When set to true they fill available with. Default false
+ * @param {activePaneNumber} number defines the tab that should be selected. Starts with 1
+ * @param {activePaneId} string alternative to activePaneNumber defines the active tab by its id. Requires that you set an id on mw-tabs-pane
+ * @param {tabChanged} function the callback that shall be executed when the tab is changed. Will pass the activePaneNumber, newPane scope, previous pane scope as params
+ * @param {removeInactiveContent} boolean defines wether inactive pane content should be removed from dom or just be set to hidden. Default false
+ *
  * @example ```html
  * <!-- change callback example -->
- * <div mw-tabs active-pane-number="myCtrl.activePane" tab-changed="myCtrl.tabChanged">
- <div mw-tabs-pane="{{'mytitle'| i18n}}">
- Tab 1
- </div>
- <div mw-tabs-pane="{{'mytitle_2'| i18n}}">
- Tab 2
- </div>
- </div>
+ * <div mw-tabs
+ *      active-pane-number="myCtrl.activePane"
+ *      tab-changed="myCtrl.tabChanged"
+ *      remove-inactive-content="true">
+ *   <div mw-tabs-pane="{{'mytitle'| i18n}}">
+ *     Tab Content 1
+ *   </div>
+ *   <div mw-tabs-pane="{{'mytitle_2'| i18n}}">
+ *     Tab Content 2
+ *   </div>
+ * </div>
  * ```
  */
   .directive('mwTabs', function ($rootScope) {

--- a/src/mw-ui-components/directives/mw_tab_bar.js
+++ b/src/mw-ui-components/directives/mw_tab_bar.js
@@ -51,7 +51,7 @@ angular.module('mwUI.UiComponents')
           activePaneIndex = null;
 
           // In case that no active pane is defined by setting activePaneNumber or Id the first pane will be selected
-          if (angular.isUndefined($scope.activePaneNumber) && angular.isUndefined($scope.activePaneId) && $scope.panes.length>0) {
+          if (angular.isUndefined($scope.activePaneNumber) && angular.isUndefined($scope.activePaneId) && $scope.panes.length > 0) {
             $scope.select($scope.panes[0]);
 
           // When a pane number is defined the pane with the index of activePaneNumber + 1 will be selected

--- a/src/mw-ui-components/directives/mw_tab_bar.js
+++ b/src/mw-ui-components/directives/mw_tab_bar.js
@@ -66,7 +66,7 @@ angular.module('mwUI.UiComponents')
           }
         };
 
-        var throttledSetInitialSelection = _.debounce(setInitialSelection, 100);
+        var throttledSetInitialSelection = _.debounce(setInitialSelection, 10);
 
         $scope.getActivePane = function () {
           var activePane;

--- a/src/mw-ui-components/directives/mw_tab_pane.js
+++ b/src/mw-ui-components/directives/mw_tab_pane.js
@@ -12,7 +12,7 @@ angular.module('mwUI.UiComponents')
       },
       transclude: true,
       replace: true,
-      require: ['^mwTabs', '^?form'],
+      require: ['^mwTabs'],
       templateUrl: 'uikit/mw-ui-components/directives/templates/mw_tab_pane.html',
       controller: function ($scope) {
         var selected = false;
@@ -28,13 +28,12 @@ angular.module('mwUI.UiComponents')
           selected = true;
         };
 
-        $scope.isSelected = function () {
+        this.isSelected = $scope.isSelected = function () {
           return selected;
         };
       },
       link: function (scope, el, attr, ctrls) {
-        var mwTabsCtrl = ctrls[0],
-            formCtrl = ctrls[1];
+        var mwTabsCtrl = ctrls[0];
 
         mwTabsCtrl.registerPane(scope);
 
@@ -44,13 +43,20 @@ angular.module('mwUI.UiComponents')
           mwTabsCtrl.unRegisterPane(scope);
         });
 
-        // Do not use ng-if to remove the transcluded tab pane content when the tab pane is in a `Form`
-        // Validation does not work when the content is removed from the dom
-        // When you have a tab bar with multiple tabs and each tab contains required input, the tab pane content
-        // must be always in the dom so the form controller knows that the inputs are existing
-        scope.canUseNgIf = function(){
-          return !formCtrl;
+        // Use ng-if to remove the transcluded tab pane content when the parent `mwTabs` controller allows it
+        // Set scope attribute `removeInactiveContent` on `mwTabs` to controll the behaviour. For complex content
+        // that is transcluded it is recommended to `removeInactiveContent` to true but be aware that it is a bit
+        // slower. However, it may have a possitive impact on the genral performance especially when the transluded content
+        // registeres a lot of event listeners and stuff
+        scope.canUseNgIf = function () {
+          var tabBarAllowsIt = mwTabsCtrl.canRemoveInactiveContent();
+          if (mwTabsCtrl && angular.isDefined(tabBarAllowsIt)) {
+            return tabBarAllowsIt;
+          } else {
+            return false;
+          }
         };
+
         scope.isInitialised = true;
       }
     };

--- a/src/mw-ui-components/directives/mw_tab_pane.js
+++ b/src/mw-ui-components/directives/mw_tab_pane.js
@@ -1,5 +1,18 @@
 angular.module('mwUI.UiComponents')
 //TODO rename
+/**
+ * @ngdoc directive
+ * @name mwUI.UiComponents.directive:mwTabsPane
+ *
+ * @description TabPane content. Requires mwTabs as parent. Defines title, icon, tooltip, etc for the tab
+ *
+ * @param {mwTabsPane} string defines the title of the tab
+ * @param {id} number defines the id. Is required when you want to select a tab by id
+ * @param {icon} string defines the icon of the tab. Not displayed when not set
+ * @param {tooltip} string defines the tooltip of the tab. Not displayed when not set
+ * @param {badge} string defines the badge of the tab. Not displayed when not set
+ * @param {isInvalid} boolean defines whether the tab should be displayed in error state.
+ */
   .directive('mwTabsPane', function () {
     return {
       scope: {

--- a/src/mw-ui-components/directives/mw_tab_pane.js
+++ b/src/mw-ui-components/directives/mw_tab_pane.js
@@ -51,6 +51,7 @@ angular.module('mwUI.UiComponents')
         scope.canUseNgIf = function(){
           return !formCtrl;
         };
+        scope.isInitialised = true;
       }
     };
   });

--- a/src/mw-ui-components/directives/templates/mw_tab_bar.html
+++ b/src/mw-ui-components/directives/templates/mw_tab_bar.html
@@ -4,7 +4,7 @@
   <ul class="nav nav-tabs"
       ng-class="{ 'nav-justified': justified }">
     <li ng-repeat="pane in panes"
-        ng-class="{ active: pane.isSelected() }">
+        ng-class="{ active: $index === getActivePaneIndex() }">
       <a ng-class="{ 'has-error': pane.isInvalid }"
          ng-click="select(pane)">
         <span ng-if="pane.icon"
@@ -18,7 +18,12 @@
     </li>
   </ul>
 
-  <div class="tab-content"
+  <div ng-show="canShowPaneContent()"
+       class="tab-content"
        ng-transclude></div>
+
+  <div ng-if="!canShowPaneContent()"
+       mw-indefinite-loading>
+  </div>
 
 </div>


### PR DESCRIPTION
- Do not remove tab content by default but make it configurable.
- By default the tab content will be hidden by ng-show but when you set the added scope attribute `removeInactiveContent` of `mwTabs` to true it will remove the content from the dom and add it when the tab becomes active. This is recommended for tab content with a complex logic