### PR TITLE
Feature/menubar fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.21.4
+## Bug Fixes
+### Menu module
+- Clean up timeouts and throttled executions when menubar, menu-entry is destroyed. Otherwise functions
+are triggered that should not be triggered which results in an exception
+
 # v1.21.3
 ## Features
 ### Ui components module

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mw-uikit",
   "description": "A toolbox to build portals with AngularJS 1.5.x that have a lot of forms and list views for example admin portals to manage data.",
   "author": "Alexander Zarges <a.zarges@mwaysolutions.com> (http://relution.io)",
-  "version": "1.21.3",
+  "version": "1.21.4",
   "license": "Apache-2.0",
   "devDependencies": {
     "angular": "1.5.7",

--- a/src/mw-menu/directives/mw_menu_entry.js
+++ b/src/mw-menu/directives/mw_menu_entry.js
@@ -51,10 +51,6 @@ angular.module('mwUI.Menu')
         };
 
         var tryToRegisterAtParent = function () {
-          if (!menuEntry) {
-            return;
-          }
-
           if (parentCtrl) {
             if (!parentCtrl.getMenuEntry()) {
               // TODO could not produce that error. In case the following exception is thrown write a test case and comment line in

--- a/src/mw-menu/directives/mw_menu_entry.js
+++ b/src/mw-menu/directives/mw_menu_entry.js
@@ -34,6 +34,7 @@ angular.module('mwUI.Menu')
           parentCtrl = ctrls[1],
           menuCtrl = ctrls[2],
           menuEntry = new mwUI.Menu.MwMenuEntry(),
+          timeouts = [],
           entryHolder;
 
         var getDomOrder = function () {
@@ -94,7 +95,7 @@ angular.module('mwUI.Menu')
 
         scope.menuEntry = menuEntry;
 
-        $timeout(tryToRegisterAtParent);
+        timeouts.push($timeout(tryToRegisterAtParent));
 
         ctrl.setMenuEntry(menuEntry);
 
@@ -117,6 +118,10 @@ angular.module('mwUI.Menu')
         });
 
         scope.$on('$destroy', function () {
+          timeouts.forEach(function (timeoutPromise) {
+            $timeout.cancel(timeoutPromise);
+          });
+
           if (entryHolder) {
             entryHolder.remove(menuEntry);
           }

--- a/src/mw-menu/directives/mw_menu_top_entries.js
+++ b/src/mw-menu/directives/mw_menu_top_entries.js
@@ -16,26 +16,52 @@ angular.module('mwUI.Menu')
         };
       },
       link: function (scope, el, attrs, ctrl) {
+        var timeouts = [],
+          isDestroyed = false;
+
         scope.entries = ctrl.getMenu();
 
-        scope.$on('mw-menu:triggerReorder', _.throttle(function () {
-          $timeout(function () {
-            scope.$broadcast('mw-menu:reorder');
-          });
-        }));
+        var issueResort = function () {
+          // Unfortunately there is no easy way to cancel a throttled function (https://github.com/jashkenas/underscore/pull/952#issuecomment-12867693)
+          // So we have to check if is is not destroyed already. Actually we would cancel the throttled function during destroy
+          if (isDestroyed) {
+            return;
+          }
+          timeouts.push(
+            $timeout(function () {
+              scope.entries.sort();
+              scope.$broadcast('mw-menu:resort');
+            })
+          );
+        };
+        var throttledIssueResort = _.throttle(issueResort, 1);
 
-        scope.$on('mw-menu:triggerResort', _.throttle(function () {
-          $timeout(function () {
-            scope.$broadcast('mw-menu:resort');
-            scope.entries.sort();
-          });
-        }));
+        var issueReorder = function () {
+          // Unfortunately there is no easy way to cancel a throttled function (https://github.com/jashkenas/underscore/pull/952#issuecomment-12867693)
+          if (isDestroyed) {
+            return;
+          }
+          timeouts.push(
+            $timeout(function () {
+              scope.$broadcast('mw-menu:reorder');
+            })
+          );
+        };
+        var throttledIssueReorder = _.throttle(issueReorder, 1);
 
-        scope.entries.on('add remove reset', _.throttle(function () {
-          $timeout(function () {
-            scope.$broadcast('mw-menu:reorder');
+        scope.$on('mw-menu:triggerReorder', throttledIssueReorder);
+
+        scope.$on('mw-menu:triggerResort', throttledIssueResort);
+
+        scope.entries.on('add remove reset', throttledIssueReorder);
+
+        scope.$on('$destroy', function () {
+          isDestroyed = true;
+          timeouts.forEach(function (timeoutPromise) {
+            $timeout.cancel(timeoutPromise);
           });
-        }));
+          scope.entries.off('add remove reset', throttledIssueReorder);
+        });
       }
     };
   });

--- a/src/mw-menu/directives/mw_menu_top_entries_test.js
+++ b/src/mw-menu/directives/mw_menu_top_entries_test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-describe('mwUi menu divider directive', function () {
+describe('mwUi menu top entries', function () {
   beforeEach(module('mwUI.Menu'));
 
   beforeEach(module('karmaDirectiveTemplates'));

--- a/src/mw-menu/directives/mw_menu_top_entries_test.js
+++ b/src/mw-menu/directives/mw_menu_top_entries_test.js
@@ -57,7 +57,7 @@ describe('mwUi menu top entries', function () {
       expect(el.find('.mw-menu-top-drop-down-item').length).toBe(1);
     });
 
-    it('removes items from the visible menu when they are removed from the menu', function(){
+    it('removes items from the visible menu when they are removed from the menu', function () {
       var el = this.buildMenuEl('' +
         '<div mw-menu-entry label="abc" url="abc">' +
         '<div ng-if="isVisible" mw-menu-entry label="sub_abc" url="abc/sub1"></div>' +
@@ -78,7 +78,7 @@ describe('mwUi menu top entries', function () {
       expect(el.find('a[href="abc/sub2"]').length).toBe(1);
     });
 
-    it('add items to the visible menu when they are removed from the menu', function(){
+    it('add items to the visible menu when they are removed from the menu', function () {
       var el = this.buildMenuEl('' +
         '<div mw-menu-entry label="abc" url="abc">' +
         '<div ng-if="isVisible" mw-menu-entry label="sub_abc" url="abc/sub1"></div>' +
@@ -98,7 +98,7 @@ describe('mwUi menu top entries', function () {
       expect(el.find('a[href="abc/sub1"]').length).toBe(1);
     });
 
-    it('resorts items to the visible menu when the order is changing', function(){
+    it('resorts items to the visible menu when the order is changing', function () {
       var el = this.buildMenuEl('' +
         '<div mw-menu-entry label="abc" url="abc">' +
         '<div mw-menu-entry label="sub_abc1" url="abc/sub1" order="order"></div>' +
@@ -121,13 +121,13 @@ describe('mwUi menu top entries', function () {
     });
   });
 
-  describe('testing cleanup on destroy', function(){
-    it('does not issue any resort, reorder tasks when the menubar is destroyed', function(){
+  describe('testing cleanup on destroy', function () {
+    it('does not issue any resort, reorder tasks when the menubar is destroyed', function () {
       var tmpl = '<div mw-menu-top-entries="menu" ng-if="menuBarIsVisible">' +
-        '<div mw-menu-entry label="abc" url="abc">'+
+        '<div mw-menu-entry label="abc" url="abc">' +
         '<div ng-if="isVisible" mw-menu-entry label="sub_abc" url="abc/sub1"></div>' +
         '<div mw-menu-entry label="sub_abc" url="abc/sub1"></div>' +
-        '</div>'+
+        '</div>' +
         '</div>';
       this.$compile(tmpl)(this.$scope);
       this.$scope.menuBarIsVisible = true;
@@ -144,12 +144,12 @@ describe('mwUi menu top entries', function () {
     });
 
     it('does not issue any resort, reorder tasks when the menubar is destroyed and there is a pending issue ' +
-      '(throttle has not been executed yet)', function(){
+      '(throttle has not been executed yet)', function () {
       var tmpl = '<div mw-menu-top-entries="menu" ng-if="menuBarIsVisible">' +
-        '<div mw-menu-entry label="abc" url="abc">'+
+        '<div mw-menu-entry label="abc" url="abc">' +
         '<div ng-if="isVisible" mw-menu-entry label="sub_abc" url="abc/sub1"></div>' +
         '<div mw-menu-entry label="sub_abc" url="abc/sub1"></div>' +
-        '</div>'+
+        '</div>' +
         '</div>';
       this.$compile(tmpl)(this.$scope);
       this.$scope.menuBarIsVisible = true;

--- a/src/mw-menu/directives/mw_menu_top_entries_test.js
+++ b/src/mw-menu/directives/mw_menu_top_entries_test.js
@@ -120,4 +120,50 @@ describe('mwUi menu divider directive', function () {
       expect(el.find('.mw-menu-top-drop-down-item ul li a').last().attr('href')).toBe('abc/sub1');
     });
   });
+
+  describe('testing cleanup on destroy', function(){
+    it('does not issue any resort, reorder tasks when the menubar is destroyed', function(){
+      var tmpl = '<div mw-menu-top-entries="menu" ng-if="menuBarIsVisible">' +
+        '<div mw-menu-entry label="abc" url="abc">'+
+        '<div ng-if="isVisible" mw-menu-entry label="sub_abc" url="abc/sub1"></div>' +
+        '<div mw-menu-entry label="sub_abc" url="abc/sub1"></div>' +
+        '</div>'+
+        '</div>';
+      this.$compile(tmpl)(this.$scope);
+      this.$scope.menuBarIsVisible = true;
+      this.$scope.isVisible = true;
+      this.$scope.$digest();
+      this.$scope.isVisible = false;
+      this.$scope.$digest();
+      jasmine.clock().tick(1);
+
+      this.$scope.menuBarIsVisible = false;
+      this.$scope.$digest();
+
+      this.$timeout.verifyNoPendingTasks();
+    });
+
+    it('does not issue any resort, reorder tasks when the menubar is destroyed and there is a pending issue ' +
+      '(throttle has not been executed yet)', function(){
+      var tmpl = '<div mw-menu-top-entries="menu" ng-if="menuBarIsVisible">' +
+        '<div mw-menu-entry label="abc" url="abc">'+
+        '<div ng-if="isVisible" mw-menu-entry label="sub_abc" url="abc/sub1"></div>' +
+        '<div mw-menu-entry label="sub_abc" url="abc/sub1"></div>' +
+        '</div>'+
+        '</div>';
+      this.$compile(tmpl)(this.$scope);
+      this.$scope.menuBarIsVisible = true;
+      this.$scope.isVisible = true;
+      this.$scope.$digest();
+      this.$scope.isVisible = false;
+      this.$scope.$digest();
+      jasmine.clock().tick(1);
+
+      this.$timeout.flush();
+      this.$scope.menuBarIsVisible = false;
+      this.$scope.$digest();
+
+      this.$timeout.verifyNoPendingTasks();
+    });
+  });
 });


### PR DESCRIPTION
- Fix bug of menubar. When it was destroyed it threw an exception because delayed functions (by $timeout, throttle) have been called that actually shouldn't be called.
Timeouts and throttled functions are now cleared during destroy