### PR TITLE
Release new version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# v1.22.0
+## Features
+- Improve memory usage by unbinding several event and rootscope listeners on $destroy
+
+## List module
+- Persist sort order in url as query param
+- Display total amount of items when items are selected
+
+## Layout module
+- Display reload button in header
+- Add possibility to pass a description into the header
+
+
 # v1.21.4
 ## Bug Fixes
 ### Menu module

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mw-uikit",
   "description": "A toolbox to build portals with AngularJS 1.5.x that have a lot of forms and list views for example admin portals to manage data.",
   "author": "Alexander Zarges <a.zarges@mwaysolutions.com> (http://relution.io)",
-  "version": "1.21.4",
+  "version": "1.22.0",
   "license": "Apache-2.0",
   "devDependencies": {
     "angular": "1.5.7",


### PR DESCRIPTION
- Improve memory usage by unbinding several event and rootscope listeners on $destroy
- Persist sort order in url as query param
- Display total amount of items when items are selected
- Display reload button in header
- Add possibility to pass a description into the header