### PR TITLE
MDM-15311: Remove watcher to update the searchval dynamically

### DIFF
--- a/src-relution/mwComponentsBb.js
+++ b/src-relution/mwComponentsBb.js
@@ -2,18 +2,18 @@
 
 angular.module('mwComponentsBb', [])
 
-/**
- * @ngdoc directive
- * @name mwComponents.directive:mwFilterableSearch
- * @element div
- * @description
- *
- * Creates a search field to filter by in the sidebar. Search is triggered on keypress 'enter'.
- *
- * @param {filterable} filterable Filterable instance.
- * @param {expression} disabled If expression evaluates to true, input is disabled.
- * @param {string} property The name of the property on which the filtering should happen.
- */
+  /**
+   * @ngdoc directive
+   * @name mwComponents.directive:mwFilterableSearch
+   * @element div
+   * @description
+   *
+   * Creates a search field to filter by in the sidebar. Search is triggered on keypress 'enter'.
+   *
+   * @param {filterable} filterable Filterable instance.
+   * @param {expression} disabled If expression evaluates to true, input is disabled.
+   * @param {string} property The name of the property on which the filtering should happen.
+   */
   .service('ignoreKeyPress', function () {
     var ENTER_KEY = 13;
     return {
@@ -118,13 +118,12 @@ angular.module('mwComponentsBb', [])
           throw new Error('[mwFilterableSearchBb] Either collection or mwCollection has to be set');
         }
 
-        scope.$watch(function () {
-          if (collection.filterable && scope.property) {
-            return collection.filterable.filterValues[scope.property];
-          }
-        }, function (val) {
-          scope.viewModel.searchVal = val;
-        });
+        /*
+         * If the collection has already a value as searchvalue, update the searchvalue. 
+         */
+        if (collection.filterable && scope.property) {
+          scope.viewModel.searchVal = collection.filterable.filterValues[scope.property];
+        }
 
         scope.$on('$destroy', function () {
           el.off();

--- a/src-relution/mwComponentsBb.js
+++ b/src-relution/mwComponentsBb.js
@@ -118,12 +118,15 @@ angular.module('mwComponentsBb', [])
           throw new Error('[mwFilterableSearchBb] Either collection or mwCollection has to be set');
         }
 
-        /*
-         * If the collection has already a value as searchvalue, update the searchvalue. 
-         */
-        if (collection.filterable && scope.property) {
-          scope.viewModel.searchVal = collection.filterable.filterValues[scope.property];
-        }
+        scope.$watch(function () {
+          if (collection.filterable && scope.property) {
+            return collection.filterable.filterValues[scope.property];
+          }
+        }, function (val) {
+          if (val !== scope.viewModel.searchVal) {
+            scope.viewModel.searchVal = val;
+          }
+        });
 
         scope.$on('$destroy', function () {
           el.off();


### PR DESCRIPTION
This MR will change the directive mwFilterableSearchBb by removing the watcher which updates the searchval based on changes in the collection filters. The search value will updated on time during the initialisation of the directive with the current searchvalue of the collection. After that point we assume that the directive updates the filter values and not the other way around. Therefor the MR removes the watcher to fix a possible loop caused by the update chain: filter->searchval -> filter