### PR TITLE
Add ids to the navigation bar to support e2e tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.22.4
+## Features
+- add id attribute to `mwMenuTopItem` and `mwMenuTopDropDownItem` to support a better navigation in e2e test cases.
+
 # v1.22.3
 ## Bug Fixes
 - Reverted "Improve memory usage by unbinding several event and rootscope listeners on $destroy" which was introduced in 1.22.0 because it's unstable

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mw-uikit",
   "description": "A toolbox to build portals with AngularJS 1.5.x that have a lot of forms and list views for example admin portals to manage data.",
   "author": "Alexander Zarges <a.zarges@mwaysolutions.com> (http://relution.io)",
-  "version": "1.22.3",
+  "version": "1.22.4",
   "license": "Apache-2.0",
   "devDependencies": {
     "angular": "1.5.7",

--- a/src/mw-menu/directives/templates/mw_menu_top_drop_down_item.html
+++ b/src/mw-menu/directives/templates/mw_menu_top_drop_down_item.html
@@ -4,13 +4,14 @@
      role="button"
      aria-haspopup="true"
      aria-expanded="false"
-     mw-menu-toggle-active-class="entry">
+     mw-menu-toggle-active-class="entry"
+     id="{{entry.get('id')}}">
     <span mw-icon="{{entry.get('icon')}}"></span>
     <span>{{entry.get('label')}}</span>
     <b class="caret"></b>
   </a>
   <ul class="dropdown-menu">
     <li ng-repeat="subEntry in entry.get('subEntries').models"
-         mw-menu-top-item="subEntry"></li>
+        mw-menu-top-item="subEntry"></li>
   </ul>
 </div>

--- a/src/mw-menu/directives/templates/mw_menu_top_item.html
+++ b/src/mw-menu/directives/templates/mw_menu_top_item.html
@@ -4,6 +4,7 @@
      ng-href="{{entry.get('url')}}"
      target="{{entry.get('target')}}"
      mw-menu-toggle-active-class="entry"
+     id="{{entry.get('id')}}"
      class="entry">
     <span ng-if="entry.get('icon')"
           mw-icon="{{entry.get('icon')}}"></span>


### PR DESCRIPTION
This MR will introduce ID's to the navigation bar items. It's necessary to support a better navigation in e2e tests