### PR TITLE
Refactored url storage

### DIFF
--- a/src/mw-utils/services/mw_url_storage.js
+++ b/src/mw-utils/services/mw_url_storage.js
@@ -1,207 +1,198 @@
 angular.module('mwUI.Utils')
 
   .service('mwUrlStorage', function ($rootScope, $location, $route) {
-    var storage = {};
+      var storage = {};
+      var removeOnUrlChangekeys = [];
+      var unbindRouteUpdate = null;
+      var unbindLocationChangeStart = null;
+      var originalReloadOnSearchValue = null;
 
-    var preventRouteReload = function () {
-      //Check whether reloadOnSearch is already disabled
-      if ($route.current.$$route.reloadOnSearch === false) {
-        return;
-      }
-      // Remember the state so we can set it to the original state after we have updated the route
-      var prevReloadOnSearchVal = $route.current.$$route.reloadOnSearch;
-      //Set reloadOnSearch false so angular does not reinitialize the controller
-      $route.current.$$route.reloadOnSearch = false;
+      var preventRouteReload = function () {
+        if (unbindRouteUpdate) {
+          unbindRouteUpdate();
+        }
+        if (unbindLocationChangeStart) {
+          unbindLocationChangeStart();
+        }
+        if (originalReloadOnSearchValue === null) {
+          originalReloadOnSearchValue = $route.current.$$route.reloadOnSearch;
+        }
 
-      var unbindRouteUpdateListener,
-        unbindRouteChangeSuccessListener;
+        unbindRouteUpdate = $rootScope.$on('$routeUpdate', function () {
+          unbindRouteUpdate();
+          unbindRouteUpdate = null;
+          var reloadPath = $location.absUrl();
+          /*
+           * For some reason when setting reloadOnSearch back to its original value a locationChange event is trigger
+           * which has to be prevented otherwise the controller will be reinitialised
+           */
+          unbindLocationChangeStart = $rootScope.$on('$locationChangeStart', function (ev, newUrl) {
+            unbindLocationChangeStart();
+            if (newUrl === reloadPath) {
+              ev.preventDefault();
+            }
+          });
+          $route.current.$$route.reloadOnSearch = originalReloadOnSearchValue;
+          originalReloadOnSearchValue = null;
+        });
 
-      //Route update is triggered when reloadOnSearch is set to true and a search param has changed
-      unbindRouteUpdateListener = $rootScope.$on('$routeUpdate', function () {
-        $route.current.$$route.reloadOnSearch = prevReloadOnSearchVal;
-        unbindRouteUpdateListener();
-        unbindRouteChangeSuccessListener();
-      });
+        // reloadOnSearch is set to false to angular will not reinitialise the controller again
+        $route.current.$$route.reloadOnSearch = false;
+      };
 
-      // //Route change success is triggered when reloadOnSearch is set to false and a search param has changed
-      unbindRouteChangeSuccessListener = $rootScope.$on('$routeChangeSuccess', function () {
-        $route.current.$$route.reloadOnSearch = prevReloadOnSearchVal;
-        unbindRouteChangeSuccessListener();
-        unbindRouteUpdateListener();
-      });
-    };
+      var cleanUpInvalidQueryParams = function () {
+        var removeKeys = _.clone(removeOnUrlChangekeys);
+        removeKeys.forEach(function (key, index) {
+          storage[key] = null;
+          removeOnUrlChangekeys.splice(index, 1);
+        });
+      };
 
-    var hasChangedValues = function (params, removeParams) {
-      var currentSearchParams = $location.search();
-      var changedParams = _.difference(_.values(params), _.values(currentSearchParams));
-
-      removeParams = _.difference(_.values(removeParams), _.values(currentSearchParams));
-      return changedParams.length > 0 || removeParams.length > 0;
-    };
-
-    var setUrlQueryParams = function (params, preferQueryOverStorage, removeKeys, options) {
-      options = options || {};
-      if (hasChangedValues(params, removeKeys)) {
+      var setUrlQueryParams = function () {
         var currentSearchParams = $location.search(),
           newSearchParams;
 
-        if (removeKeys) {
-          removeKeys.forEach(function (key) {
-            currentSearchParams[key] = null;
-          });
-        }
-
-        if (preferQueryOverStorage) {
-          newSearchParams = _.extend(params, currentSearchParams);
-        } else {
-          newSearchParams = _.extend(currentSearchParams, params);
-        }
-
+        newSearchParams = _.extend(currentSearchParams, storage);
         preventRouteReload();
         $location.search(newSearchParams);
+        $location.replace();
+      };
 
-        if (!options.keepInHistory) {
-          $location.replace();
+      $rootScope.$on('$routeChangeStart', function (ev, newRoute, oldRoute) {
+        if (newRoute && oldRoute &&
+          newRoute.originalPath !== oldRoute.originalPath &&
+          removeOnUrlChangekeys.length > 0) {
+          cleanUpInvalidQueryParams();
+          setUrlQueryParams();
         }
-      }
-    };
+      });
 
-    $rootScope.$on('$locationChangeSuccess', function (ev, newUrl, oldUrl) {
-      if (newUrl !== oldUrl) {
-        setUrlQueryParams(storage, true);
-      }
-    });
-
-    return {
-      /*
-       * Return the value that is stored in the url for a key
-       *
-       * params:
-       * key: string
-       */
-      getItem: function (key) {
-        return $location.search()[key];
-      },
-      /*
-       * Calls setItem but allows you to set a whole object instead of a key,value
-       *
-       * params:
-       * obj: object
-       * options: {
-       *   removeOnUrlChange: boolean
-       *   keepInHistory: boolean
-       * }
-       */
-      setObject: function (obj, options) {
-        options = options || {};
-        var wasChanged = false;
-        if (_.isObject(obj)) {
-          for (var key in obj) {
-            if (obj.hasOwnProperty(key) && storage[key] !== obj[key]) {
-              if (!options.removeOnUrlChange) {
+      return {
+        /*
+         * Return the value that is stored in the url for a key
+         *
+         * params:
+         * key: string
+         */
+        getItem: function (key) {
+          return $location.search()[key];
+        },
+        /*
+         * Calls setItem but allows you to set a whole object instead of a key,value
+         *
+         * params:
+         * obj: object
+         * options: {
+         *   removeOnUrlChange: boolean
+         * }
+         */
+        setObject: function (obj, options) {
+          options = options || {};
+          var wasChanged = false;
+          if (_.isObject(obj)) {
+            for (var key in obj) {
+              if (obj.hasOwnProperty(key) && storage[key] !== obj[key]) {
+                if (options.removeOnUrlChange && removeOnUrlChangekeys.indexOf(key) === -1) {
+                  removeOnUrlChangekeys.push(key);
+                }
                 storage[key] = obj[key];
-              }
-              wasChanged = true;
-            }
-          }
-        } else {
-          throw new Error('[mwUrlStorage] parameter has to be an object otherwise setItem(key, val) should be called ');
-        }
-
-        if (wasChanged) {
-          setUrlQueryParams(obj, false, false, options);
-        }
-      },
-      /*
-       * Save a key value pair as query param in the url
-       * The query will be in the url until you call removeItem('key') also on url change
-       * You don't have to worry about the param it will just stay
-       *
-       * In cases where you don't wan't to keep the query param in the url forever you can set the options param
-       * removeOnUrlChange to true (default is false
-       *
-       * The query won't be stored in the url history so when using the back button you will not go back to the previous
-       * query state but to the previous url
-       * In cases where you want to go to store the query in the history you can set the options param
-       * `keepInHistory` to true
-       *
-       * params:
-       * key: string
-       * value: string
-       * options: {
-       *   removeOnUrlChange: boolean
-       *   keepInHistory: boolean
-       * }
-       */
-      setItem: function (key, value, options) {
-        options = options || {};
-        if (storage[key] !== value) {
-          if (!options.removeOnUrlChange) {
-            storage[key] = value;
-          }
-          var obj = {};
-          obj[key] = value;
-          setUrlQueryParams(obj, false, false, options);
-        }
-      },
-      /*
-       * Calls removeItem but allows you to remove a whole object instead of a key
-       *
-       * params:
-       * obj: object
-       */
-      removeObject: function (obj) {
-        var wasChanged = false;
-        var removeKeys = [];
-        if (_.isObject(obj)) {
-          for (var key in obj) {
-            if (obj.hasOwnProperty(key)) {
-              if (storage[key] || this.getItem(key)) {
-                storage[key] = null;
                 wasChanged = true;
-                removeKeys.push(key);
               }
             }
+          } else {
+            throw new Error('[mwUrlStorage] parameter has to be an object otherwise setItem(key, val) should be called ');
           }
-        } else {
-          throw new Error('[mwUrlStorage] parameter has to be an object otherwise deleteItem(key, val) should be called ');
-        }
 
-        if (wasChanged) {
-          setUrlQueryParams(storage, false, removeKeys);
-        }
-      },
-      /*
-       * Removes a key with its value from the url
-       *
-       * params:
-       * key: string
-       */
-      removeItem: function (key) {
-        if (storage[key]) {
-          storage[key] = null;
-          setUrlQueryParams(storage, false, [key]);
-          return true;
-        } else if (this.getItem(key)) {
-          setUrlQueryParams(storage, false, [key]);
-          return true;
-        } else {
-          return false;
-        }
-      },
-      /*
-       * Removes all items that have been set by setItem or setObject from the url
-       * Other url query params that have been set e.g. by calling $location.search() won't be affected
-       */
-      clear: function () {
-        var removeKeys = [];
-        for (var key in storage) {
-          if (storage.hasOwnProperty(key) && storage[key]) {
-            removeKeys.push(key);
+          if (wasChanged) {
+            setUrlQueryParams();
           }
+        },
+        /*
+         * Save a key value pair as query param in the url
+         * The query will be in the url until you call removeItem('key') also on url change
+         * You don't have to worry about the param it will just stay
+         *
+         * In cases where you don't wan't to keep the query param in the url forever you can set the options param
+         * removeOnUrlChange to true (default is false
+         *
+         * The query won't be stored in the url history so when using the back button you will not go back to the previous
+         * query state but to the previous url
+         *
+         * params:
+         * key: string
+         * value: string
+         * options: {
+         *   removeOnUrlChange: boolean
+         * }
+         */
+        setItem: function (key, value, options) {
+          options = options || {};
+          if (storage[key] !== value) {
+            if (options.removeOnUrlChange && removeOnUrlChangekeys.indexOf(key) === -1) {
+              removeOnUrlChangekeys.push(key);
+            }
+            storage[key] = value;
+            setUrlQueryParams();
+          }
+        },
+        /*
+         * Calls removeItem but allows you to remove a whole object instead of a key
+         *
+         * params:
+         * obj: object
+         */
+        removeObject: function (obj) {
+          var wasChanged = false;
+          if (_.isObject(obj)) {
+            for (var key in obj) {
+              if (obj.hasOwnProperty(key)) {
+                if (storage[key] || this.getItem(key)) {
+                  storage[key] = null;
+                  wasChanged = true;
+                }
+                var removeOnUrlChangeKeyIndex = removeOnUrlChangekeys.indexOf(key);
+                if (removeOnUrlChangeKeyIndex !== -1) {
+                  removeOnUrlChangekeys.slice(removeOnUrlChangeKeyIndex, 1);
+                }
+              }
+            }
+          } else {
+            throw new Error('[mwUrlStorage] parameter has to be an object otherwise deleteItem(key, val) should be called ');
+          }
+
+          if (wasChanged) {
+            setUrlQueryParams();
+          }
+        },
+        /*
+         * Removes a key with its value from the url
+         *
+         * params:
+         * key: string
+         */
+        removeItem: function (key) {
+          var removeOnUrlChangeKeyIndex = removeOnUrlChangekeys.indexOf(key);
+          if (removeOnUrlChangeKeyIndex !== -1) {
+            removeOnUrlChangekeys.slice(removeOnUrlChangeKeyIndex, 1);
+          }
+          if (storage[key]) {
+            storage[key] = null;
+            setUrlQueryParams();
+            return true;
+          } else {
+            return false;
+          }
+        },
+        /*
+         * Removes all items that have been set by setItem or setObject from the url
+         * Other url query params that have been set e.g. by calling $location.search() won't be affected
+         */
+        clear: function () {
+          storage = {};
+          removeOnUrlChangekeys = [];
+          setUrlQueryParams();
         }
-        storage = {};
-        setUrlQueryParams(storage, false, removeKeys);
-      }
-    };
-  });
+      };
+    }
+  )
+;

--- a/src/mw-utils/services/mw_url_storage.js
+++ b/src/mw-utils/services/mw_url_storage.js
@@ -60,9 +60,10 @@ angular.module('mwUI.Utils')
 
       $rootScope.$on('$routeChangeStart', function (ev, newRoute, oldRoute) {
         if (newRoute && oldRoute &&
-          newRoute.originalPath !== oldRoute.originalPath &&
-          removeOnUrlChangekeys.length > 0) {
-          cleanUpInvalidQueryParams();
+          newRoute.originalPath !== oldRoute.originalPath) {
+          if (removeOnUrlChangekeys.length > 0) {
+            cleanUpInvalidQueryParams(newRoute.params);
+          }
           setUrlQueryParams();
         }
       });

--- a/src/mw-utils/services/mw_url_storage.js
+++ b/src/mw-utils/services/mw_url_storage.js
@@ -8,6 +8,10 @@ angular.module('mwUI.Utils')
       var originalReloadOnSearchValue = null;
 
       var preventRouteReload = function () {
+        // In case the path has not route definition do nothing
+        if (!$route.current || !$route.current.$$route) {
+          return;
+        }
         if (unbindRouteUpdate) {
           unbindRouteUpdate();
         }

--- a/src/mw-utils/services/mw_url_storage_test.js
+++ b/src/mw-utils/services/mw_url_storage_test.js
@@ -153,15 +153,6 @@ describe('MwUrlStorageTest', function () {
     expect(locationSpy.search()).toEqual({});
   });
 
-  it('discard the query param after a route change when the option removeOnUrlChange is set to true and the url still contains the param', function () {
-    locationSpy.path('/irrelevant');
-    subject.setItem('abc', 'IRRELEVANT', {removeOnUrlChange: true});
-
-    locationSpy.path('/irrelevant-change?abc=IRRELEVANT');
-
-    expect(locationSpy.search()).toEqual({abc: null});
-  });
-
   it('discard the query param after a route change when the option removeOnUrlChange is set to true but keeps the other', function () {
     locationSpy.path('/irrelevant');
     subject.setItem('abc', 'IRRELEVANT', {removeOnUrlChange: true});
@@ -169,6 +160,15 @@ describe('MwUrlStorageTest', function () {
 
     locationSpy.path('/irrelevant-change');
 
-    expect(locationSpy.search()).toEqual({xyz: 'IRRELEVANT-STAY', abc: null});
+    expect(locationSpy.search()).toEqual({xyz: 'IRRELEVANT-STAY'});
+  });
+
+  it('discard the query param after a route change when the option removeOnUrlChange is set to true but keeps the url query param', function () {
+    locationSpy.path('/irrelevant');
+    subject.setItem('abc', 'IRRELEVANT', {removeOnUrlChange: true});
+
+    locationSpy.path('/irrelevant-change?xyz=IRRELEVANT-STAY');
+
+    expect(locationSpy.search()).toEqual({xyz: 'IRRELEVANT-STAY'});
   });
 });

--- a/src/mw-utils/services/mw_url_storage_test.js
+++ b/src/mw-utils/services/mw_url_storage_test.js
@@ -144,15 +144,6 @@ describe('MwUrlStorageTest', function () {
     expect(locationSpy.search()).toEqual({abc: 'IRRELEVANT'});
   });
 
-  it('does not overwrite a changed url query param with the storage param on a route change', function () {
-    locationSpy.path('/irrelevant');
-    subject.setItem('abc', 'IRRELEVANT');
-
-    locationSpy.path('/irrelevant-change?abc=CHANGED_IRRELEVANT');
-
-    expect(subject.getItem('abc')).toEqual('CHANGED_IRRELEVANT');
-  });
-
   it('discard the query param after a route change when the option removeOnUrlChange is set to true', function () {
     locationSpy.path('/irrelevant');
     subject.setItem('abc', 'IRRELEVANT', {removeOnUrlChange: true});


### PR DESCRIPTION
- make sure that query params that are set to removeOnUrlChange are removed on url change (Fix #202)
- make sure that controller is not reinitialised when a query param is set by url storage
