### PR TITLE
Feature/menu bar fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.24.2
+## Features
+- Add `is-visible` attribute to mw-menu-entry to hide menu entries without removing them from the dom.
+When using `ng-if` to hide/show menu entries it can lead to a jump in the navigation bar when it is re-added  
+
 # v1.24.1
 ## Bug Fixes
 - Fix upload state of file uploader for small files.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mw-uikit",
   "description": "A toolbox to build portals with AngularJS 1.5.x that have a lot of forms and list views for example admin portals to manage data.",
   "author": "Alexander Zarges <a.zarges@mwaysolutions.com> (http://relution.io)",
-  "version": "1.24.1",
+  "version": "1.24.2",
   "license": "Apache-2.0",
   "devDependencies": {
     "angular": "1.7.3",

--- a/src/mw-menu/directives/mw_menu_entry.js
+++ b/src/mw-menu/directives/mw_menu_entry.js
@@ -12,6 +12,7 @@ angular.module('mwUI.Menu')
         class: '@styleClass',
         order: '=',
         activeUrls: '=',
+        isVisible: '=',
         action: '&',
         isActive: '&'
       },
@@ -35,7 +36,8 @@ angular.module('mwUI.Menu')
           menuCtrl = ctrls[2],
           menuEntry = new mwUI.Menu.MwMenuEntry(),
           timeouts = [],
-          entryHolder;
+          entryHolder,
+          isTopEntry;
 
         var getDomOrder = function () {
           var orderDomEl = el;
@@ -60,6 +62,7 @@ angular.module('mwUI.Menu')
             entryHolder = parentCtrl.getMenuEntry().get('subEntries');
           } else if (menuCtrl) {
             entryHolder = menuCtrl.getMenu();
+            isTopEntry = true;
           }
 
           if (entryHolder && !entryHolder.get(menuEntry)) {
@@ -83,7 +86,8 @@ angular.module('mwUI.Menu')
             } : null,
             isActive: attrs.isActive ? function () {
               return scope.isActive();
-            } : null
+            } : null,
+            isVisible: _.isUndefined(scope.isVisible) ? true : scope.isVisible
           });
         };
 
@@ -126,7 +130,7 @@ angular.module('mwUI.Menu')
           ctrl.setMenuEntry(menuEntry);
         });
 
-        scope.$watchGroup(['id', 'label', 'url', 'icon', 'class', 'order', 'target'], setMenuEntry);
+        scope.$watchGroup(['id', 'label', 'url', 'icon', 'class', 'order', 'target', 'isVisible'], setMenuEntry);
       }
     };
   });

--- a/src/mw-menu/directives/mw_menu_top_item.js
+++ b/src/mw-menu/directives/mw_menu_top_item.js
@@ -1,6 +1,6 @@
 angular.module('mwUI.Menu')
 
-  .directive('mwMenuTopItem', function () {
+  .directive('mwMenuTopItem', function ($timeout) {
     return {
       scope: {
         entry: '=mwMenuTopItem'
@@ -8,10 +8,12 @@ angular.module('mwUI.Menu')
       templateUrl: 'uikit/mw-menu/directives/templates/mw_menu_top_item.html',
       link: function(scope){
         scope.executeAction = function(){
-          var action = scope.entry.get('action');
-          if(action && typeof action === 'function' ){
-            action();
-          }
+          $timeout(function(){
+            var action = scope.entry.get('action');
+            if(action && typeof action === 'function' ){
+              action();
+            }
+          });
         };
       }
     };

--- a/src/mw-menu/directives/templates/mw_menu_top_entries.html
+++ b/src/mw-menu/directives/templates/mw_menu_top_entries.html
@@ -1,5 +1,7 @@
 <ul class="mw-menu-top-entries nav navbar-nav" ng-class="{'navbar-right': right}">
-  <li ng-repeat="entry in entries.models" class="entry {{entry.get('class')}}">
+  <li ng-repeat="entry in entries.models"
+      ng-if="entry.get('isVisible')"
+      class="entry {{entry.get('class')}}">
     <div ng-if="entry.hasSubEntries()"
          mw-menu-top-drop-down-item="entry"></div>
     <div ng-if="!entry.hasSubEntries()"

--- a/src/mw-menu/directives/templates/mw_menu_top_item.html
+++ b/src/mw-menu/directives/templates/mw_menu_top_item.html
@@ -1,4 +1,5 @@
 <div class="mw-menu-top-item"
+     ng-if="entry.get('isVisible')"
      ng-click="executeAction()">
   <a ng-if="entry.get('type') === 'ENTRY'"
      ng-href="{{entry.get('url')}}"

--- a/src/mw-menu/models/mw_menu_entry.js
+++ b/src/mw-menu/models/mw_menu_entry.js
@@ -11,7 +11,8 @@ var MwMenuEntry = window.mwUI.Backbone.NestedModel.extend({
       order: null,
       action: null,
       isActive: null,
-      target: null
+      target: null,
+      isVisible: null
     };
   },
   nested: function () {


### PR DESCRIPTION
Provide option `is-visible` to hide menu entries without removing them from the dom. Fixes the issue that the menubar resorts itself after relogin in the relution portal (MDM-1576)
Portal has to be changed to use `is-visible` instead of `ng-if` for the top level entries. Also top level entries that are hidden by using the `rln-permission` have to be migrated to use `is-visible` 