### PR TITLE
Remove angular sanitize from file include

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.24.3
+## Bug Fixes
+- Remove angular sanitize from file include in mwUI.Relution to provide angular 1.5 support
+
 # v1.24.2
 ## Features
 - Add `is-visible` attribute to mw-menu-entry to hide menu entries without removing them from the dom.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,7 +61,6 @@ module.exports = function (grunt) {
           '!src-relution/test/**/*.js',
           '.tmp/templates-relution.js',
           '.tmp/templates-relution-i18n.js',
-          'libs/angular-sanitize/angular-sanitize.js',
           'libs/showdown/dist/showdown.js',
           'libs/jquery-ui/ui/widget.js',
           'libs/blueimp-file-upload/js/jquery.fileupload.js',

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mw-uikit",
   "description": "A toolbox to build portals with AngularJS 1.5.x that have a lot of forms and list views for example admin portals to manage data.",
   "author": "Alexander Zarges <a.zarges@mwaysolutions.com> (http://relution.io)",
-  "version": "1.24.2",
+  "version": "1.24.3",
   "license": "Apache-2.0",
   "devDependencies": {
     "angular": "1.7.3",


### PR DESCRIPTION
Remove angular sanitize from file include in mwUI.Relution to provide angular 1.5 support. 
Angular sanitize has to be provided like angular itself in projects that are using the uikit