### PR TITLE
Feature/fileupload default formdata fix

### DIFF
--- a/src-relution/mwFileUpload/mwFileUpload.js
+++ b/src-relution/mwFileUpload/mwFileUpload.js
@@ -285,6 +285,10 @@ angular.module('mwFileUpload', [])
             updateUploaderOptions({
               formData: val
             });
+          } else {
+            updateUploaderOptions({
+              formData: {}
+            });
           }
         }, true);
 

--- a/src-relution/mwFileUpload/mwFileUpload.js
+++ b/src-relution/mwFileUpload/mwFileUpload.js
@@ -195,7 +195,7 @@ angular.module('mwFileUpload', [])
 
         scope.onUploadStart = function() {
           scope.viewModel.state = 'UPLOADING';
-        }
+        };
         /* progressData = {
             data:blueImpXhr,
             progress: progress,


### PR DESCRIPTION
Fix IOT-948: fakeremeberedpassword is sent by fileupload when selecting a file.
The fileuplaoder is using by default all form fields that are available and sent it to the server.
the fakeusername and password fields are set by each form as a work around for the browser autofill.
When no formData is set it is set to an empty object to prevent the default behaviour of the fileuplaoder